### PR TITLE
Add docker-compose.yml for persistent Neo4j storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+services:
+  neo4j:
+    image: neo4j:5.19
+    container_name: azure-tenant-grapher-neo4j
+    restart: unless-stopped
+    ports:
+      - "7687:7687"
+      - "7474:7474"
+    environment:
+      NEO4J_AUTH: neo4j/azure-grapher-2024
+      NEO4J_dbms_memory_pagecache_size: 1G
+      NEO4J_dbms_memory_heap_initial__size: 1G
+      NEO4J_dbms_memory_heap_max__size: 2G
+    volumes:
+      - ./neo4j-data:/data
+      - ./neo4j-logs:/logs
+      - ./neo4j-import:/var/lib/neo4j/import
+      - ./neo4j-plugins:/plugins


### PR DESCRIPTION
Adds a docker-compose.yml to run Neo4j with persistent data, logs, import, and plugins directories mapped to local folders. This ensures graph data is not lost across container restarts or host reboots.