### PR TITLE
fix: Change spec output from ./specs directory to current directory

### DIFF
--- a/.github/azure-tenant-grapher-spec.md
+++ b/.github/azure-tenant-grapher-spec.md
@@ -343,7 +343,7 @@ AZURE_OPENAI_MODEL_CHAT=gpt-4
 AZURE_OPENAI_MODEL_REASONING=gpt-4
 
 # Specification Generation
-AZTG_SPEC_OUTPUT_DIR=./specs
+AZTG_SPEC_OUTPUT_DIR=.
 AZTG_SPEC_INCLUDE_AI=true
 AZTG_SPEC_INCLUDE_CONFIG=true
 AZTG_SPEC_ANONYMIZATION_SEED=optional-seed
@@ -548,7 +548,7 @@ uv run python scripts/cli.py generate-spec [--limit N] [--output PATH]
 ```
 
 - `--limit` (optional): Maximum number of resources to include (default: from config).
-- `--output` (optional): Custom output path (default: auto-generated in ./specs/).
+- `--output` (optional): Custom output path (default: auto-generated in current directory).
 
 Example:
 
@@ -558,13 +558,19 @@ azure-tenant-grapher generate-spec --limit 100 --output my-tenant-spec.md
 
 ### Specification File Location
 
-Generated specifications are saved in the `./specs/` directory with a timestamped filename by default:
+Generated specifications are saved in the current directory with a timestamped filename by default:
 
 ```
-./specs/{YYYYMMDD_HHMMSS}_tenant_spec.md
+{YYYYMMDD_HHMMSS}_tenant_spec.md
 ```
 
-Example: `./specs/20250616_132221_tenant_spec.md`
+Example: `20250616_132221_tenant_spec.md`
+
+You can specify a custom output path using the `--output` flag:
+
+```bash
+azure-tenant-grapher generate-spec --output /path/to/my-spec.md
+```
 
 ### Anonymization Features
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -165,7 +165,7 @@ class SpecificationConfig:
 
     resource_limit: Optional[int] = field(default_factory=lambda: None)
     output_directory: str = field(
-        default_factory=lambda: os.getenv("AZTG_SPEC_OUTPUT_DIR", "./specs")
+        default_factory=lambda: os.getenv("AZTG_SPEC_OUTPUT_DIR", ".")
     )
     include_ai_summaries: bool = field(
         default_factory=lambda: os.getenv("AZTG_SPEC_INCLUDE_AI", "true").lower()

--- a/src/graph_visualizer.py
+++ b/src/graph_visualizer.py
@@ -477,17 +477,14 @@ class GraphVisualizer:
         """Generate HTML for the tenant specification link - ENHANCED."""
         import glob
 
-        # If not provided or doesn't exist, look for latest in ./specs/
+        # If not provided or doesn't exist, look for latest in current directory
         if not specification_path or not os.path.exists(specification_path):
-            specs_dir = os.path.join(os.getcwd(), "specs")
-            if os.path.isdir(specs_dir):
-                spec_files = sorted(
-                    glob.glob(os.path.join(specs_dir, "*_tenant_spec.md")), reverse=True
-                )
-                if spec_files:
-                    specification_path = spec_files[0]
-                else:
-                    return ""
+            current_dir = os.getcwd()
+            spec_files = sorted(
+                glob.glob(os.path.join(current_dir, "*_tenant_spec.md")), reverse=True
+            )
+            if spec_files:
+                specification_path = spec_files[0]
             else:
                 return ""
 

--- a/src/tenant_spec_generator.py
+++ b/src/tenant_spec_generator.py
@@ -189,7 +189,12 @@ class TenantSpecificationGenerator:
         # Write to file
         if not output_path:
             output_path = self._get_default_output_path()
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        
+        # Only create directory if it's not the current directory
+        output_dir = os.path.dirname(output_path)
+        if output_dir and output_dir != "." and output_dir != os.getcwd():
+            os.makedirs(output_dir, exist_ok=True)
+            
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(markdown)
         logger.info(f"Specification written to {output_path}")

--- a/src/visualization/html_template_builder.py
+++ b/src/visualization/html_template_builder.py
@@ -217,17 +217,14 @@ class HtmlTemplateBuilder:
         """
         import glob
 
-        # If not provided or doesn't exist, look for latest in ./specs/
+        # If not provided or doesn't exist, look for latest in current directory
         if not specification_path or not os.path.exists(specification_path):
-            specs_dir = os.path.join(os.getcwd(), "specs")
-            if os.path.isdir(specs_dir):
-                spec_files = sorted(
-                    glob.glob(os.path.join(specs_dir, "*_tenant_spec.md")), reverse=True
-                )
-                if spec_files:
-                    specification_path = spec_files[0]
-                else:
-                    return ""
+            current_dir = os.getcwd()
+            spec_files = sorted(
+                glob.glob(os.path.join(current_dir, "*_tenant_spec.md")), reverse=True
+            )
+            if spec_files:
+                specification_path = spec_files[0]
             else:
                 return ""
 


### PR DESCRIPTION
## Summary

This PR changes the default output location for tenant specifications from a  subdirectory to the current working directory, as requested.

## Changes Made

### Code Changes
- ✅ **src/config_manager.py**: Updated  default from  to 
- ✅ **src/graph_visualizer.py**: Updated spec file lookup to search in current directory instead of 
- ✅ **src/visualization/html_template_builder.py**: Updated spec file lookup to search in current directory
- ✅ **src/tenant_spec_generator.py**: Added logic to avoid creating directories when output is current directory

### Documentation Updates
- ✅ **azure-tenant-grapher-spec.md**: Updated environment variable example and CLI usage documentation
- ✅ Updated specification file location examples to show current directory output

## Behavior Changes

### Before
- Generated files saved to: 
- Required creating  directory
- Spec file lookup searched in  directory

### After  
- Generated files saved to:  (current directory)
- No subdirectory creation needed
- Spec file lookup searches in current directory
- Custom output paths still supported via  flag

## Impact

This change simplifies the file structure by:
- Eliminating the need for a separate specs subdirectory
- Placing generated files directly in the working directory
- Maintaining backward compatibility for custom output paths
- Keeping the visualization integration working with the new location

## Testing

- [x] Verified config manager defaults to current directory
- [x] Verified spec generator doesn't create unnecessary directories
- [x] Verified visualization components search current directory
- [x] Updated documentation reflects new behavior