### PR TITLE
fix: make visualization control buttons pure green on black

### DIFF
--- a/spa/renderer/src/components/graph/GraphVisualization.tsx
+++ b/spa/renderer/src/components/graph/GraphVisualization.tsx
@@ -626,12 +626,12 @@ export const GraphVisualization: React.FC = () => {
           </ButtonGroup>
           <Box sx={{ display: 'flex', gap: 1 }}>
             <Tooltip title="Show Legend">
-              <IconButton onClick={() => setLegendOpen(true)} size="small" sx={{ color: '#4caf50' }}>
+              <IconButton onClick={() => setLegendOpen(true)} size="small" sx={{ color: '#4caf50', '&:hover': { backgroundColor: 'rgba(76, 175, 80, 0.1)' } }}>
                 <InfoIcon />
               </IconButton>
             </Tooltip>
             <Tooltip title="Refresh">
-              <IconButton onClick={fetchGraphData} size="small" sx={{ color: '#4caf50' }}>
+              <IconButton onClick={fetchGraphData} size="small" sx={{ color: '#4caf50', '&:hover': { backgroundColor: 'rgba(76, 175, 80, 0.1)' } }}>
                 <RefreshIcon />
               </IconButton>
             </Tooltip>
@@ -1018,7 +1018,7 @@ export const GraphVisualization: React.FC = () => {
           <Box sx={{ p: 2 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
               <Typography variant="h6">Node Details</Typography>
-              <IconButton onClick={() => setDetailsOpen(false)}>
+              <IconButton onClick={() => setDetailsOpen(false)} sx={{ color: '#4caf50', '&:hover': { backgroundColor: 'rgba(76, 175, 80, 0.1)' } }}>
                 <CloseIcon />
               </IconButton>
             </Box>
@@ -1086,7 +1086,7 @@ export const GraphVisualization: React.FC = () => {
         <Box sx={{ p: 2 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
             <Typography variant="h6">Graph Legend</Typography>
-            <IconButton onClick={() => setLegendOpen(false)}>
+            <IconButton onClick={() => setLegendOpen(false)} sx={{ color: '#4caf50', '&:hover': { backgroundColor: 'rgba(76, 175, 80, 0.1)' } }}>
               <CloseIcon />
             </IconButton>
           </Box>


### PR DESCRIPTION
Fixes #146

## Summary
Updates visualization control buttons to be pure green (#4caf50) on black background with no grey elements for better visibility.

## Changes
- Updated all IconButton components in GraphVisualization.tsx
- Added consistent sx styling with green color and hover effects
- Removed any grey color elements from visualization controls

## Visual Changes
- Show Legend button: Now green on black
- Refresh button: Now green on black
- Close buttons in drawers: Now green on black
- Hover effect: Subtle green background at 10% opacity