### PR TITLE
fix: visualization control icons with green on black styling

### DIFF
--- a/spa/renderer/src/components/graph/GraphVisualization.tsx
+++ b/spa/renderer/src/components/graph/GraphVisualization.tsx
@@ -609,17 +609,41 @@ export const GraphVisualization: React.FC = () => {
           <Typography variant="subtitle2" sx={{ color: 'white', mb: 1 }}>View Controls</Typography>
           <ButtonGroup size="small" sx={{ mb: 2 }}>
             <Tooltip title="Zoom In">
-              <Button onClick={handleZoomIn} sx={{ color: '#4caf50', borderColor: '#4caf50' }}>
+              <Button onClick={handleZoomIn} sx={{ 
+                backgroundColor: '#000000',
+                color: '#4caf50', 
+                borderColor: '#4caf50',
+                '&:hover': {
+                  backgroundColor: '#000000',
+                  borderColor: '#4caf50'
+                }
+              }}>
                 <ZoomInIcon />
               </Button>
             </Tooltip>
             <Tooltip title="Zoom Out">
-              <Button onClick={handleZoomOut} sx={{ color: '#4caf50', borderColor: '#4caf50' }}>
+              <Button onClick={handleZoomOut} sx={{ 
+                backgroundColor: '#000000',
+                color: '#4caf50', 
+                borderColor: '#4caf50',
+                '&:hover': {
+                  backgroundColor: '#000000',
+                  borderColor: '#4caf50'
+                }
+              }}>
                 <ZoomOutIcon />
               </Button>
             </Tooltip>
             <Tooltip title="Fit to Screen">
-              <Button onClick={handleFit} sx={{ color: '#4caf50', borderColor: '#4caf50' }}>
+              <Button onClick={handleFit} sx={{ 
+                backgroundColor: '#000000',
+                color: '#4caf50', 
+                borderColor: '#4caf50',
+                '&:hover': {
+                  backgroundColor: '#000000',
+                  borderColor: '#4caf50'
+                }
+              }}>
                 <FitIcon />
               </Button>
             </Tooltip>
@@ -687,6 +711,13 @@ export const GraphVisualization: React.FC = () => {
                 startIcon={<SearchIcon />}
                 size="small"
                 fullWidth
+                sx={{
+                  backgroundColor: '#000000',
+                  color: '#4caf50',
+                  '&:hover': {
+                    backgroundColor: '#000000'
+                  }
+                }}
               >
                 Search
               </Button>
@@ -695,7 +726,15 @@ export const GraphVisualization: React.FC = () => {
                 onClick={clearAllFilters}
                 startIcon={<ClearIcon />}
                 size="small"
-                sx={{ color: 'white', borderColor: 'white' }}
+                sx={{ 
+                  backgroundColor: '#000000',
+                  color: '#4caf50', 
+                  borderColor: '#4caf50',
+                  '&:hover': {
+                    backgroundColor: '#000000',
+                    borderColor: '#4caf50'
+                  }
+                }}
               >
                 Clear
               </Button>
@@ -709,15 +748,15 @@ export const GraphVisualization: React.FC = () => {
             variant="outlined" 
             onClick={() => setFiltersOpen(!filtersOpen)}
             startIcon={<FilterIcon />}
-            color={filtersOpen ? 'primary' : 'inherit'}
             size="small"
             fullWidth
             sx={{ 
-              color: 'white', 
-              borderColor: 'white',
+              backgroundColor: '#000000',
+              color: '#4caf50', 
+              borderColor: '#4caf50',
               '&:hover': {
-                borderColor: 'white',
-                backgroundColor: 'rgba(255, 255, 255, 0.1)'
+                backgroundColor: '#000000',
+                borderColor: '#4caf50'
               }
             }}
           >

--- a/spa/renderer/src/components/graph/GraphVisualization.tsx
+++ b/spa/renderer/src/components/graph/GraphVisualization.tsx
@@ -626,12 +626,26 @@ export const GraphVisualization: React.FC = () => {
           </ButtonGroup>
           <Box sx={{ display: 'flex', gap: 1 }}>
             <Tooltip title="Show Legend">
-              <IconButton onClick={() => setLegendOpen(true)} size="small" sx={{ color: '#4caf50', '&:hover': { backgroundColor: 'rgba(76, 175, 80, 0.1)' } }}>
+              <IconButton onClick={() => setLegendOpen(true)} size="small" sx={{ 
+                color: '#4caf50', 
+                backgroundColor: '#000000',
+                '&:hover': { 
+                  backgroundColor: '#000000',
+                  filter: 'brightness(1.2)'
+                }
+              }}>
                 <InfoIcon />
               </IconButton>
             </Tooltip>
             <Tooltip title="Refresh">
-              <IconButton onClick={fetchGraphData} size="small" sx={{ color: '#4caf50', '&:hover': { backgroundColor: 'rgba(76, 175, 80, 0.1)' } }}>
+              <IconButton onClick={fetchGraphData} size="small" sx={{ 
+                color: '#4caf50', 
+                backgroundColor: '#000000',
+                '&:hover': { 
+                  backgroundColor: '#000000',
+                  filter: 'brightness(1.2)'
+                }
+              }}>
                 <RefreshIcon />
               </IconButton>
             </Tooltip>
@@ -1018,7 +1032,14 @@ export const GraphVisualization: React.FC = () => {
           <Box sx={{ p: 2 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
               <Typography variant="h6">Node Details</Typography>
-              <IconButton onClick={() => setDetailsOpen(false)} sx={{ color: '#4caf50', '&:hover': { backgroundColor: 'rgba(76, 175, 80, 0.1)' } }}>
+              <IconButton onClick={() => setDetailsOpen(false)} sx={{ 
+                color: '#4caf50', 
+                backgroundColor: '#000000',
+                '&:hover': { 
+                  backgroundColor: '#000000',
+                  filter: 'brightness(1.2)'
+                }
+              }}>
                 <CloseIcon />
               </IconButton>
             </Box>
@@ -1086,7 +1107,14 @@ export const GraphVisualization: React.FC = () => {
         <Box sx={{ p: 2 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
             <Typography variant="h6">Graph Legend</Typography>
-            <IconButton onClick={() => setLegendOpen(false)} sx={{ color: '#4caf50', '&:hover': { backgroundColor: 'rgba(76, 175, 80, 0.1)' } }}>
+            <IconButton onClick={() => setLegendOpen(false)} sx={{ 
+              color: '#4caf50', 
+              backgroundColor: '#000000',
+              '&:hover': { 
+                backgroundColor: '#000000',
+                filter: 'brightness(1.2)'
+              }
+            }}>
               <CloseIcon />
             </IconButton>
           </Box>


### PR DESCRIPTION
## Summary
- Fixed visualization control button styling to use green outline on black background
- Updated all Button and IconButton components in GraphVisualization.tsx
- Ensured consistent styling across all control buttons

## Changes
- Added explicit backgroundColor: '#000000' to all visualization control buttons
- Set color: '#4caf50' (green) for button text/icons
- Added borderColor: '#4caf50' for consistent green outlines
- Applied styling to both Button and IconButton components

## Test plan
- [x] Launch the SPA with `uv run atg start`
- [x] Navigate to the Visualize tab
- [x] Verify all control buttons have black background with green icons/text
- [x] Test each button functionality remains unchanged

Fixes #173

🤖 Generated with [Claude Code](https://claude.ai/code)