### PR TITLE
feat: add app-registration CLI command for Azure AD setup

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -90,6 +90,7 @@ try:
 
     # (Removed: from src.cli_commands import create_tenant_command)
     from src.cli_commands import (
+        app_registration_command,
         build_command_handler,
         create_tenant_command,
         generate_spec_command_handler,
@@ -682,6 +683,7 @@ cli.add_command(generate_sim_doc, "gensimdoc")
 cli.add_command(create_tenant_command, "create-tenant")
 cli.add_command(spa_start, "start")
 cli.add_command(spa_stop, "stop")
+cli.add_command(app_registration_command, "app-registration")
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
- Added new `atg app-registration` command for streamlined Azure AD app registration
- Supports both automated creation (with Azure CLI) and manual instructions
- Configures all necessary permissions for Azure Tenant Grapher

## Features
- Detects Azure CLI availability and adjusts workflow accordingly
- Creates app registration with required Microsoft Graph and Azure Management permissions
- Generates client secret automatically
- Outputs ready-to-use .env configuration
- Provides clear manual instructions when Azure CLI is not available

## Test plan
- [x] Test command help: `uv run atg app-registration --help`
- [x] Verify manual instructions display when Azure CLI is not available
- [ ] Test with Azure CLI installed to verify automated creation
- [ ] Verify generated .env configuration is correct

Fixes #176

🤖 Generated with [Claude Code](https://claude.ai/code)