### PR TITLE
feat: start MCP server with SPA and add restore-db alias

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -685,6 +685,9 @@ cli.add_command(spa_start, "start")
 cli.add_command(spa_stop, "stop")
 cli.add_command(app_registration_command, "app-registration")
 
+# Add alias for restore command
+cli.add_command(restore_database, "restore-db")
+
 
 @cli.command()
 @click.option(

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -146,7 +146,9 @@ def async_command(f: Callable[..., Coroutine[Any, Any, Any]]) -> Callable[..., A
             # If the async command returns a sentinel indicating dashboard exit, exit here
             if result == "__DASHBOARD_EXIT__":
                 # Extract debug flag from context if available
-                debug = getattr(args[0], 'obj', {}).get('debug', False) if args else False
+                debug = (
+                    getattr(args[0], "obj", {}).get("debug", False) if args else False
+                )
                 if debug:
                     print(
                         "[DEBUG] EXIT SENTINEL '__DASHBOARD_EXIT__' detected in async_command. Exiting now.",
@@ -156,7 +158,9 @@ def async_command(f: Callable[..., Coroutine[Any, Any, Any]]) -> Callable[..., A
                 sys.exit(0)
             if result == "__NO_DASHBOARD_BUILD_COMPLETE__":
                 # Extract debug flag from context if available
-                debug = getattr(args[0], 'obj', {}).get('debug', False) if args else False
+                debug = (
+                    getattr(args[0], "obj", {}).get("debug", False) if args else False
+                )
                 if debug:
                     print(
                         "[DEBUG] EXIT SENTINEL '__NO_DASHBOARD_BUILD_COMPLETE__' detected in async_command. Exiting now.",
@@ -238,7 +242,7 @@ def cli(ctx: click.Context, log_level: str, debug: bool) -> None:
     ctx.ensure_object(dict)
     ctx.obj["log_level"] = log_level.upper()
     ctx.obj["debug"] = debug
-    
+
     # Print debug environment block if debug is enabled
     print_cli_env_block("STARTUP", debug)
 
@@ -685,9 +689,6 @@ cli.add_command(spa_start, "start")
 cli.add_command(spa_stop, "stop")
 cli.add_command(app_registration_command, "app-registration")
 
-# Add alias for restore command
-cli.add_command(restore_database, "restore-db")
-
 
 @cli.command()
 @click.option(
@@ -762,6 +763,10 @@ def restore_database(path: str) -> None:
         click.echo("The Neo4j database has been restarted with the restored data.")
     else:
         click.echo("❌ Database restore failed. Check the logs for details.")
+
+
+# Add alias for restore command
+cli.add_command(restore_database, "restore-db")
 
 
 @cli.command("wipe")

--- a/src/cli_commands.py
+++ b/src/cli_commands.py
@@ -1069,7 +1069,7 @@ def spa_start():
                 err=True,
             )
             return
-        
+
         # Verify the build created the main entry point
         main_entry = os.path.join(spa_dir, "dist", "main", "index.js")
         if not os.path.exists(main_entry):
@@ -1090,13 +1090,16 @@ def spa_start():
                     [sys.executable, "-m", "src.mcp.server"],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
-                    env={**os.environ, "PYTHONPATH": os.path.dirname(os.path.dirname(__file__))}
+                    env={
+                        **os.environ,
+                        "PYTHONPATH": os.path.dirname(os.path.dirname(__file__)),
+                    },
                 )
-                
+
                 # Save MCP PID
                 with open(MCP_PIDFILE, "w") as f:
                     f.write(str(mcp_proc.pid))
-                    
+
                 click.echo(f"✅ MCP server started (PID: {mcp_proc.pid})")
             else:
                 click.echo("⚠️  MCP server already running, skipping...")
@@ -1129,7 +1132,7 @@ def spa_stop():
     """Stop the local SPA/Electron dashboard and MCP server."""
     spa_stopped = False
     mcp_stopped = False
-    
+
     # Stop SPA
     if os.path.exists(SPA_PIDFILE):
         try:
@@ -1398,7 +1401,7 @@ def app_registration_command(tenant_id: Optional[str], name: str, redirect_uri: 
             click.echo(f"❌ Failed to stop SPA: {e}", err=True)
     else:
         click.echo("⚠️  SPA is not running (no pidfile found).")
-    
+
     # Stop MCP server
     if os.path.exists(MCP_PIDFILE):
         try:
@@ -1415,7 +1418,7 @@ def app_registration_command(tenant_id: Optional[str], name: str, redirect_uri: 
             click.echo(f"❌ Failed to stop MCP server: {e}", err=True)
     else:
         click.echo("⚠️  MCP server is not running (no pidfile found).")
-    
+
     if spa_stopped or mcp_stopped:
         click.echo("✅ Services stopped and pidfiles cleaned up.")
     else:


### PR DESCRIPTION
## Summary
- MCP server now starts automatically with the SPA
- Added restore-db as an alias for the restore command
- Improved process management for both SPA and MCP server

## Changes
- Modified `atg start` to also start the MCP server in the background
- Modified `atg stop` to also stop the MCP server
- Added MCP_PIDFILE tracking for proper process management  
- Added `restore-db` as an alias for the `restore` command
- Updated command descriptions to reflect MCP server management

## Test plan
- [x] Run `atg start` and verify both SPA and MCP server start
- [x] Check that MCP server PID file is created in outputs/
- [x] Run `atg stop` and verify both services stop
- [x] Test `atg restore-db` alias works the same as `atg restore`

Fixes #180

🤖 Generated with [Claude Code](https://claude.ai/code)