### PR TITLE
fix: update create-tenant command help text

### DIFF
--- a/src/cli_commands.py
+++ b/src/cli_commands.py
@@ -994,7 +994,7 @@ def create_tenant_from_markdown(text: str):
 @click.command("create-tenant")
 @click.argument("markdown_file", type=click.Path(exists=True))
 def create_tenant_command(markdown_file: str):
-    """Create a tenant from a markdown file."""
+    """Create a tenant graph from a tenant spec."""
     try:
         ensure_neo4j_running()
         with open(markdown_file, encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- Updated help text for create-tenant command to be more accurate

## Changes
- Changed from "Create a tenant from a markdown file"
- To "Create a tenant graph from a tenant spec"
- Better describes that the command creates a graph representation from a specification

## Test plan
- [x] Run `atg --help` and verify updated help text
- [x] Run `atg create-tenant --help` and verify description

Fixes #181

🤖 Generated with [Claude Code](https://claude.ai/code)