### PR TITLE
feat: show MCP server status on SPA status bar

### DIFF
--- a/spa/backend/src/server.ts
+++ b/spa/backend/src/server.ts
@@ -340,6 +340,35 @@ app.post('/api/neo4j/stop', async (req, res) => {
 });
 
 /**
+ * MCP server status endpoint
+ */
+app.get('/api/mcp/status', async (req, res) => {
+  try {
+    // Check if MCP pidfile exists
+    const mcpPidfile = path.join(process.cwd(), 'outputs', 'mcp_server.pid');
+    
+    if (fs.existsSync(mcpPidfile)) {
+      const pid = parseInt(fs.readFileSync(mcpPidfile, 'utf-8').trim());
+      
+      // Check if process is actually running
+      try {
+        process.kill(pid, 0); // Signal 0 checks if process exists
+        res.json({ running: true, pid });
+      } catch {
+        // Process not running, clean up pidfile
+        fs.unlinkSync(mcpPidfile);
+        res.json({ running: false });
+      }
+    } else {
+      res.json({ running: false });
+    }
+  } catch (error) {
+    console.error('Failed to check MCP status:', error);
+    res.json({ running: false, error: error instanceof Error ? error.message : 'Unknown error' });
+  }
+});
+
+/**
  * Get environment configuration
  */
 app.get('/api/config/env', (req, res) => {

--- a/spa/renderer/src/components/common/StatusBar.tsx
+++ b/spa/renderer/src/components/common/StatusBar.tsx
@@ -8,6 +8,7 @@ import {
   Business as TenantIcon,
   Storage as DatabaseIcon,
   Api as BackendIcon,
+  Psychology as McpIcon,
 } from '@mui/icons-material';
 import axios from 'axios';
 import { useTenantName } from '../../hooks/useTenantName';
@@ -28,6 +29,7 @@ const StatusBar: React.FC<StatusBarProps> = ({ connectionStatus }) => {
   const tenantName = useTenantName();
   const [activeProcesses, setActiveProcesses] = useState<ActiveProcess[]>([]);
   const [neo4jStatus, setNeo4jStatus] = useState<'connected' | 'disconnected'>('disconnected');
+  const [mcpStatus, setMcpStatus] = useState<'connected' | 'disconnected'>('disconnected');
 
   // Get active background operations from app state (only show ones with valid PIDs)
   const activeOperations = Array.from(state.backgroundOperations.values())
@@ -65,12 +67,23 @@ const StatusBar: React.FC<StatusBarProps> = ({ connectionStatus }) => {
       }
     };
 
+    const checkMcpStatus = async () => {
+      try {
+        const response = await axios.get('http://localhost:3001/api/mcp/status');
+        setMcpStatus(response.data.running ? 'connected' : 'disconnected');
+      } catch (error) {
+        setMcpStatus('disconnected');
+      }
+    };
+
     fetchActiveProcesses();
     checkNeo4jStatus();
+    checkMcpStatus();
     
     const interval = setInterval(() => {
       fetchActiveProcesses();
       checkNeo4jStatus();
+      checkMcpStatus();
     }, 5000); // Update every 5 seconds
 
     return () => clearInterval(interval);
@@ -168,6 +181,17 @@ const StatusBar: React.FC<StatusBarProps> = ({ connectionStatus }) => {
             icon={<DatabaseIcon />}
             label={neo4jStatus === 'connected' ? 'Neo4j' : 'Neo4j Offline'}
             color={neo4jStatus === 'connected' ? 'success' : 'error'}
+            variant="outlined"
+          />
+        </Tooltip>
+        
+        {/* MCP Server Status */}
+        <Tooltip title="Model Context Protocol server status">
+          <Chip
+            size="small"
+            icon={<McpIcon />}
+            label={mcpStatus === 'connected' ? 'MCP' : 'MCP Offline'}
+            color={mcpStatus === 'connected' ? 'success' : 'error'}
             variant="outlined"
           />
         </Tooltip>


### PR DESCRIPTION
## Summary
- Added MCP server status indicator to the SPA status bar
- Shows real-time status of the Model Context Protocol server

## Changes
- Added `/api/mcp/status` endpoint to backend server
- Checks MCP pidfile and validates process is actually running
- Added MCP status chip to StatusBar component
- Updates status every 5 seconds along with other status checks
- Shows green chip when MCP is running, red when offline
- Includes Psychology icon for visual clarity

## Test plan
- [x] Start SPA with `uv run atg start`
- [x] Verify MCP status shows as connected (green)
- [x] Stop MCP server and verify status changes to offline (red)
- [x] Restart MCP server and verify status updates back to connected

Related to #180

🤖 Generated with [Claude Code](https://claude.ai/code)