### PR TITLE
feat: rename Build to Scan throughout codebase

### DIFF
--- a/spa/renderer/src/App.tsx
+++ b/spa/renderer/src/App.tsx
@@ -11,7 +11,7 @@ import { useApp } from './context/AppContext';
 // Lazy load heavy components
 const StatusTab = lazy(() => import('./components/tabs/StatusTab'));
 const LogsTab = lazy(() => import('./components/tabs/LogsTab'));
-const BuildTab = lazy(() => import('./components/tabs/BuildTab'));
+const ScanTab = lazy(() => import('./components/tabs/ScanTab'));
 const CLITab = lazy(() => import('./components/tabs/CLITab'));
 const GenerateSpecTab = lazy(() => import('./components/tabs/GenerateSpecTab'));
 const GenerateIaCTab = lazy(() => import('./components/tabs/GenerateIaCTab'));
@@ -122,7 +122,7 @@ const App: React.FC = () => {
                 <Route path="/" element={<Navigate to="/status" replace />} />
                 <Route path="/status" element={<StatusTab />} />
                 <Route path="/logs" element={<LogsTab />} />
-                <Route path="/build" element={<BuildTab />} />
+                <Route path="/scan" element={<ScanTab />} />
                 <Route path="/cli" element={<CLITab />} />
                 <Route path="/visualize" element={<VisualizeTab />} />
                 <Route path="/generate-spec" element={<GenerateSpecTab />} />

--- a/spa/renderer/src/components/common/TabNavigation.tsx
+++ b/spa/renderer/src/components/common/TabNavigation.tsx
@@ -10,7 +10,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Dashboard as StatusIcon,
   BugReport as LogsIcon,
-  Build as BuildIcon,
+  Search as ScanIcon,
   Visibility as VisualizeIcon,
   Description as SpecIcon,
   Code as CodeIcon,
@@ -25,7 +25,7 @@ import {
 // All tabs in a simple flat array
 const allTabs = [
   { label: 'Status', path: '/status', icon: <StatusIcon /> },
-  { label: 'Build', path: '/build', icon: <BuildIcon /> },
+  { label: 'Scan', path: '/scan', icon: <ScanIcon /> },
   { label: 'Visualize', path: '/visualize', icon: <VisualizeIcon /> },
   { label: 'Generate Spec', path: '/generate-spec', icon: <SpecIcon /> },
   { label: 'Generate IaC', path: '/generate-iac', icon: <CodeIcon /> },

--- a/spa/renderer/src/components/tabs/ScanTab.tsx
+++ b/spa/renderer/src/components/tabs/ScanTab.tsx
@@ -52,19 +52,19 @@ interface DBStats {
   relTypeCount?: number;
 }
 
-const BuildTab: React.FC = () => {
+const ScanTab: React.FC = () => {
   const { state, dispatch } = useApp();
   const { addBackgroundOperation, updateBackgroundOperation, removeBackgroundOperation } = useBackgroundOperations();
   const { isConnected, subscribeToProcess, unsubscribeFromProcess, getProcessOutput } = useWebSocket();
-  const logger = useLogger('Build');
+  const logger = useLogger('Scan');
   
   // State declarations
   const [tenantId, setTenantId] = useState(state.config.tenantId || '');
   const [hasResourceLimit, setHasResourceLimit] = useState(false);
   const [resourceLimit, setResourceLimit] = useState<number>(100);
-  const [maxLlmThreads, setMaxLlmThreads] = useState<number>(5);
-  const [maxBuildThreads, setMaxBuildThreads] = useState<number>(10);
-  const [rebuildEdges, setRebuildEdges] = useState(false);
+  const [maxLlmThreads, setMaxLlmThreads] = useState<number>(20);
+  const [maxBuildThreads, setMaxBuildThreads] = useState<number>(20);
+  const [rebuildEdges, setRebuildEdges] = useState(true);
   const [noAadImport, setNoAadImport] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [currentProcessId, setCurrentProcessId] = useState<string | null>(null);
@@ -457,8 +457,8 @@ const BuildTab: React.FC = () => {
       // Add to background operations tracker
       addBackgroundOperation({
         id: processId,
-        type: 'Build',
-        name: `Building graph for ${tenantId}`,
+        type: 'Scan',
+        name: `Scanning tenant ${tenantId}`,
         // Backend handles PID internally, so we don't include it
       });
       
@@ -659,7 +659,7 @@ const BuildTab: React.FC = () => {
         // Build Configuration Form
         <Paper sx={{ p: 3, mb: 2 }}>
           <Typography variant="h6" gutterBottom>
-            {dbPopulated ? 'Update Graph Database' : 'Build Graph Database'}
+            {dbPopulated ? 'Update Graph Database' : 'Scan Azure Tenant'}
           </Typography>
           
           {error && (
@@ -780,7 +780,7 @@ const BuildTab: React.FC = () => {
                 onClick={handleStart}
                 size="large"
               >
-                {dbPopulated ? 'Update Database' : 'Start Build'}
+                {dbPopulated ? 'Update Database' : 'Start Scan'}
               </Button>
             </Box>
           </Grid>
@@ -801,4 +801,4 @@ const BuildTab: React.FC = () => {
   );
 };
 
-export default BuildTab;
+export default ScanTab;

--- a/spa/tests/components/ScanTab.test.tsx
+++ b/spa/tests/components/ScanTab.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
-import BuildTab from '../../renderer/src/components/tabs/BuildTab';
+import ScanTab from '../../renderer/src/components/tabs/ScanTab';
 import { AppProvider } from '../../renderer/src/context/AppContext';
 
 // Mock the validation utilities
@@ -23,7 +23,7 @@ const renderWithProviders = (component: React.ReactElement) => {
   );
 };
 
-describe('BuildTab', () => {
+describe('ScanTab', () => {
   beforeEach(() => {
     // Reset mocks
     jest.clearAllMocks();
@@ -40,10 +40,10 @@ describe('BuildTab', () => {
     };
   });
 
-  test('renders build tab with all required fields', () => {
-    renderWithProviders(<BuildTab />);
+  test('renders scan tab with all required fields', () => {
+    renderWithProviders(<ScanTab />);
     
-    expect(screen.getByText('Build Azure Tenant Graph')).toBeInTheDocument();
+    expect(screen.getByText('Scan Azure Tenant')).toBeInTheDocument();
     expect(screen.getByLabelText(/Tenant ID/i)).toBeInTheDocument();
     expect(screen.getByText(/Resource Limit/i)).toBeInTheDocument();
     expect(screen.getByText(/Max LLM Threads/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Renamed Build tab to Scan tab throughout the SPA
- Updated default values for better performance
- Changed UI text to reflect scanning terminology

## Changes
- Renamed `BuildTab.tsx` to `ScanTab.tsx`
- Updated route from `/build` to `/scan`
- Changed tab label from "Build" to "Scan" with Search icon
- Updated button text from "Start Build" to "Start Scan"
- Changed operation type from "Build" to "Scan" in background operations
- Updated heading from "Build Graph Database" to "Scan Azure Tenant"
- Renamed test file from `BuildTab.test.tsx` to `ScanTab.test.tsx`

## Default Value Updates
- Max LLM Threads: 5 → 20
- Max Build/Scan Threads: 10 → 20  
- Rebuild Edges: unchecked → checked by default

## Test plan
- [x] Launch SPA with `uv run atg start`
- [x] Navigate to Scan tab (formerly Build)
- [x] Verify tab shows "Scan" with search icon
- [x] Verify default values are updated
- [x] Test scanning functionality works as before

Fixes #184

🤖 Generated with [Claude Code](https://claude.ai/code)