### PR TITLE
fix: Electron app now quits properly when window is closed

### DIFF
--- a/spa/main/index.ts
+++ b/spa/main/index.ts
@@ -185,9 +185,9 @@ app.on('window-all-closed', () => {
     backendProcess.kill('SIGTERM');
   }
   
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
+  // Always quit the app when the window is closed
+  // This is a single-window application, so we want it to fully quit
+  app.quit();
 });
 
 app.on('before-quit', (event) => {


### PR DESCRIPTION
## Summary
- Fixed issue where Electron app process remained running after closing the window
- App now fully terminates on all platforms when the window is closed

## Problem
- On macOS, the app would stay running in the background after closing the window
- This followed standard macOS behavior but is inappropriate for a single-window application
- Users had to manually quit the app from the dock or force quit

## Solution
- Modified `window-all-closed` event handler to always call `app.quit()`
- Removed platform-specific check for macOS
- Ensures consistent behavior across all platforms

## Test plan
- [x] Launch app with `uv run atg start`
- [x] Close the window using the window manager close button (red X on macOS)
- [x] Verify the app process fully terminates
- [x] Verify backend server and all child processes are cleaned up

Fixes #185

🤖 Generated with [Claude Code](https://claude.ai/code)