### PR TITLE
fix: remove merge conflict markers causing SyntaxError

### DIFF
--- a/src/cli_commands.py
+++ b/src/cli_commands.py
@@ -1397,30 +1397,3 @@ def app_registration_command(tenant_id: Optional[str], name: str, redirect_uri: 
         # Clean up temp file
         if os.path.exists(manifest_path):
             os.remove(manifest_path)
-=======
-            click.echo(f"❌ Failed to stop SPA: {e}", err=True)
-    else:
-        click.echo("⚠️  SPA is not running (no pidfile found).")
-
-    # Stop MCP server
-    if os.path.exists(MCP_PIDFILE):
-        try:
-            with open(MCP_PIDFILE) as f:
-                pid = int(f.read().strip())
-            try:
-                os.kill(pid, signal.SIGTERM)
-                click.echo("🛑 Sent SIGTERM to MCP server.")
-                mcp_stopped = True
-            except Exception as e:
-                click.echo(f"⚠️  Could not terminate MCP server: {e}", err=True)
-            os.remove(MCP_PIDFILE)
-        except Exception as e:
-            click.echo(f"❌ Failed to stop MCP server: {e}", err=True)
-    else:
-        click.echo("⚠️  MCP server is not running (no pidfile found).")
-
-    if spa_stopped or mcp_stopped:
-        click.echo("✅ Services stopped and pidfiles cleaned up.")
-    else:
-        click.echo("⚠️  No services were running.")
->>>>>>> 786f1c8 (feat: start MCP server automatically with atg start)

--- a/tests/test_cli_syntax.py
+++ b/tests/test_cli_syntax.py
@@ -1,0 +1,67 @@
+"""Test that CLI modules have valid Python syntax."""
+
+import ast
+import sys
+from pathlib import Path
+import pytest
+
+
+def test_cli_commands_syntax():
+    """Test that cli_commands.py has valid Python syntax."""
+    cli_commands_path = Path(__file__).parent.parent / "src" / "cli_commands.py"
+    
+    # Read the file content
+    with open(cli_commands_path, 'r', encoding='utf-8') as f:
+        source_code = f.read()
+    
+    # Try to parse it as valid Python
+    try:
+        ast.parse(source_code)
+    except SyntaxError as e:
+        pytest.fail(f"Syntax error in cli_commands.py at line {e.lineno}: {e.msg}")
+
+
+def test_cli_script_syntax():
+    """Test that cli.py has valid Python syntax."""
+    cli_script_path = Path(__file__).parent.parent / "scripts" / "cli.py"
+    
+    # Read the file content  
+    with open(cli_script_path, 'r', encoding='utf-8') as f:
+        source_code = f.read()
+    
+    # Try to parse it as valid Python
+    try:
+        ast.parse(source_code)
+    except SyntaxError as e:
+        pytest.fail(f"Syntax error in cli.py at line {e.lineno}: {e.msg}")
+
+
+def test_can_import_cli():
+    """Test that we can import the CLI without errors."""
+    try:
+        # Add parent directory to path
+        sys.path.insert(0, str(Path(__file__).parent.parent))
+        
+        # Try to import cli_commands
+        import src.cli_commands
+        
+        # Try to import the main CLI
+        from scripts.cli import cli
+        
+    except SyntaxError as e:
+        pytest.fail(f"Cannot import CLI due to syntax error: {e}")
+    except ImportError as e:
+        # ImportError is okay if dependencies are missing, we're just checking syntax
+        if "invalid syntax" in str(e):
+            pytest.fail(f"Cannot import CLI due to syntax error: {e}")
+        # Otherwise pass - we're only testing syntax, not dependencies
+        pass
+    finally:
+        # Remove from path
+        if str(Path(__file__).parent.parent) in sys.path:
+            sys.path.remove(str(Path(__file__).parent.parent))
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Fixed SyntaxError in cli_commands.py preventing CLI from running
- Removed merge conflict markers and duplicate code from lines 1400-1426  
- Added syntax validation tests to catch similar issues in the future

## Issue
After merging PR #180, merge conflict markers were left in the code causing:
```
SyntaxError: invalid syntax at line 1400
```

## Solution
- Removed the duplicate spa_stop code and conflict markers
- Added comprehensive syntax tests for CLI modules
- Verified CLI now runs without errors

## Test Results
✅ All syntax tests pass
✅ CLI runs without errors
✅ `atg stop` command works correctly

🤖 Generated with Claude Code