### PR TITLE
fix: update Scan tab connection message

### DIFF
--- a/spa/renderer/src/components/tabs/ScanTab.tsx
+++ b/spa/renderer/src/components/tabs/ScanTab.tsx
@@ -527,7 +527,7 @@ const ScanTab: React.FC = () => {
       {/* Connection Status for Connected State */}
       {connectionStatus === 'connected' && !isRunning && (
         <Alert severity="success" sx={{ mb: 2 }}>
-          ✓ Connected to backend server - Ready to start builds with real-time monitoring
+          ✓ Connected to backend server - Ready to start scanning your tenant
         </Alert>
       )}
       


### PR DESCRIPTION
## Summary
- Changed message to be more accurate about scanning functionality
- Better user experience with clearer messaging

## Changes
- Updated message from 'Ready to start builds with real-time monitoring'
- Changed to 'Ready to start scanning your tenant'

Fixes #191

🤖 Generated with Claude Code