### PR TITLE
fix: make Azure AD warning text red on Configure tab

### DIFF
--- a/spa/renderer/src/components/tabs/ConfigTab.tsx
+++ b/spa/renderer/src/components/tabs/ConfigTab.tsx
@@ -234,7 +234,7 @@ const ConfigTab: React.FC = () => {
             
             {(!config.find(c => c.key === 'AZURE_CLIENT_ID')?.value || 
               !config.find(c => c.key === 'AZURE_CLIENT_SECRET')?.value) && (
-              <Alert severity="info" sx={{ mt: 2 }}>
+              <Alert severity="error" sx={{ mt: 2 }}>
                 Azure AD credentials not configured. Click "Create App Registration" to set up authentication.
               </Alert>
             )}


### PR DESCRIPTION
## Summary
- Warning about missing Azure AD credentials now displays in red
- Better visibility for important configuration requirements

## Changes
- Changed Alert severity from 'info' to 'error'
- Red color highlights the importance of proper authentication setup

Fixes #192

🤖 Generated with Claude Code