### PR TITLE
fix: Correct CLI parameter usage in SPA tabs

### DIFF
--- a/spa/renderer/src/components/tabs/CreateTenantTab.tsx
+++ b/spa/renderer/src/components/tabs/CreateTenantTab.tsx
@@ -70,7 +70,7 @@ const CreateTenantTab: React.FC = () => {
       const tempPath = `/tmp/tenant-spec-${Date.now()}.json`;
       await window.electronAPI.file.write(tempPath, specContent);
 
-      const result = await window.electronAPI.cli.execute('create-tenant', ['--spec', tempPath, '--tenant', selectedTenant]);
+      const result = await window.electronAPI.cli.execute('create-tenant', [tempPath]);
 
       window.electronAPI.on('process:output', (data: any) => {
         if (data.id === result.data.id) {

--- a/spa/renderer/src/components/tabs/GenerateIaCTab.tsx
+++ b/spa/renderer/src/components/tabs/GenerateIaCTab.tsx
@@ -92,7 +92,6 @@ const GenerateIaCTab: React.FC = () => {
     const args = [
       '--tenant-id', tenantId,
       '--format', outputFormat,
-      '--tenant', selectedTenant,
     ];
 
     if (domainName) {

--- a/spa/renderer/src/components/tabs/ScanTab.tsx
+++ b/spa/renderer/src/components/tabs/ScanTab.tsx
@@ -434,7 +434,6 @@ const ScanTab: React.FC = () => {
 
     const args = [
       '--tenant-id', tenantId,
-      '--tenant', selectedTenant,
       '--max-llm-threads', maxLlmThreads.toString(),
       '--max-build-threads', maxBuildThreads.toString(),
     ];


### PR DESCRIPTION
## Summary
Fixes critical bug where the SPA was passing incorrect CLI parameters causing the build command to fail with:
```
Error: No such option: --tenant Did you mean --tenant-id?
```

## Changes
- **ScanTab.tsx**: Removed duplicate `--tenant` parameter (already had correct `--tenant-id`)
- **GenerateIaCTab.tsx**: Removed incorrect `--tenant` parameter (should only use `--tenant-id`)  
- **CreateTenantTab.tsx**: Fixed to pass markdown file path directly without any `--tenant` parameter
- **UndeployTab.tsx**: No change needed - correctly uses `--tenant` parameter

## Testing
- [x] Verified build command now works in SPA
- [x] Checked all CLI parameter usage across tabs
- [x] Confirmed each command receives correct parameters

## Screenshot
User reported issue showing the error in the Build tab when attempting to run scan/build operation.

🤖 Generated with [Claude Code](https://claude.ai/code)