### PR TITLE
fix: Correct TextMessage import for agent mode

### DIFF
--- a/src/agent_mode.py
+++ b/src/agent_mode.py
@@ -388,10 +388,10 @@ Cypher Query:"""
             model=llm_config.model_chat,
         )
 
-        from autogen_agentchat.messages import TextMessage
+        from autogen_core.models import SystemMessage
 
         response = await model_client.create(
-            [TextMessage(content=query_prompt, source="system")]
+            [SystemMessage(content=query_prompt)]
         )
 
         # Extract the generated query
@@ -449,7 +449,7 @@ Answer:"""
 
             # Call LLM to generate answer
             answer_response = await model_client.create(
-                [TextMessage(content=answer_prompt, source="system")]
+                [SystemMessage(content=answer_prompt)]
             )
             final_answer = answer_response.content.strip()
 
@@ -459,6 +459,8 @@ Answer:"""
             print("\n❌ No results returned from database", flush=True)
 
     except Exception as e:
+        import traceback
         print(f"\n❌ Error in manual processing: {e}")
+        traceback.print_exc()
 
     # (No extra debug output)


### PR DESCRIPTION
## Summary
- Fix agent mode error: "Unknown message type: <class 'autogen_agentchat.messages.TextMessage'>"
- Use correct message type for Azure OpenAI client

## Problem
The agent mode was failing with an error about unknown message type when processing queries from the SPA.

## Solution
Use `SystemMessage` from `autogen_core.models` instead of `TextMessage` from `autogen_agentchat.messages`, which is the correct type expected by AzureOpenAIChatCompletionClient.

## Test plan
- [ ] Launch SPA
- [ ] Go to Agent Mode tab
- [ ] Click on a sample query card
- [ ] Verify the query executes without errors
- [ ] Check that results are displayed correctly

🤖 Generated with [Claude Code](https://claude.ai/code)