### PR TITLE
Fix empty tooltip in visualization tab

### DIFF
--- a/spa/renderer/src/components/graph/GraphVisualization.tsx
+++ b/spa/renderer/src/components/graph/GraphVisualization.tsx
@@ -357,21 +357,38 @@ export const GraphVisualization: React.FC = () => {
     const visNodes = data.nodes
       .filter(node => nodeTypes.has(node.type))
       .filter(nodeMatchesFilters)
-      .map(node => ({
-        id: node.id,
-        label: node.label,
-        title: `${node.type}: ${node.label}`,
-        color: NODE_COLORS[node.type] || NODE_COLORS.Default,
-        shape: 'dot',
-        size: 20,
-        font: {
-          size: 12,
-          color: '#2c3e50'
-        },
-        borderWidth: 2,
-        borderWidthSelected: 4,
-        ...node
-      }));
+      .map(node => {
+        // Create detailed HTML tooltip content
+        const tooltipContent = `
+          <div style="padding: 8px; background-color: #1a1a1a; color: #ffffff; border: 1px solid #4caf50; border-radius: 4px; font-family: 'Segoe UI', Arial, sans-serif; max-width: 300px;">
+            <div style="font-weight: bold; color: #4caf50; margin-bottom: 8px; font-size: 14px;">${node.label}</div>
+            <div style="margin-bottom: 4px; font-size: 12px;"><strong>Type:</strong> ${node.type}</div>
+            ${node.properties?.resourceGroup ? `<div style="margin-bottom: 4px; font-size: 12px;"><strong>Resource Group:</strong> ${node.properties.resourceGroup}</div>` : ''}
+            ${node.properties?.location ? `<div style="margin-bottom: 4px; font-size: 12px;"><strong>Location:</strong> ${node.properties.location}</div>` : ''}
+            ${node.properties?.subscriptionId ? `<div style="margin-bottom: 4px; font-size: 12px;"><strong>Subscription:</strong> ${node.properties.subscriptionId}</div>` : ''}
+            ${node.properties?.sku ? `<div style="margin-bottom: 4px; font-size: 12px;"><strong>SKU:</strong> ${node.properties.sku}</div>` : ''}
+            ${node.properties?.status ? `<div style="margin-bottom: 4px; font-size: 12px;"><strong>Status:</strong> ${node.properties.status}</div>` : ''}
+            ${node.properties?.provisioningState ? `<div style="margin-bottom: 4px; font-size: 12px;"><strong>State:</strong> ${node.properties.provisioningState}</div>` : ''}
+            <div style="margin-top: 8px; font-size: 10px; color: #888;">Click for more details</div>
+          </div>
+        `;
+
+        return {
+          id: node.id,
+          label: node.label,
+          title: tooltipContent,
+          color: NODE_COLORS[node.type] || NODE_COLORS.Default,
+          shape: 'dot',
+          size: 20,
+          font: {
+            size: 12,
+            color: '#2c3e50'
+          },
+          borderWidth: 2,
+          borderWidthSelected: 4,
+          ...node
+        };
+      });
 
     // Transform edges for vis-network
     const visEdges = data.edges

--- a/spa/renderer/src/index.css
+++ b/spa/renderer/src/index.css
@@ -314,3 +314,21 @@ body {
   left: 50%;
   transform: translate(-50%, -50%);
 }
+
+/* Vis-network tooltip styles */
+.vis-tooltip {
+  position: absolute;
+  visibility: hidden;
+  padding: 8px;
+  white-space: normal;
+  font-family: 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', sans-serif;
+  font-size: 12px;
+  color: #ffffff;
+  background-color: #1a1a1a;
+  border: 1px solid #4caf50;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  z-index: 10000;
+  max-width: 350px;
+}


### PR DESCRIPTION
Fixes #231

## Summary
Fixed empty black box tooltip that appeared when hovering over nodes in the visualization tab.

## Changes
- Enhanced tooltip content to show detailed node information
- Added CSS styling for tooltip visibility and theming
- Display node name, type, resource group, location, and other properties

## Testing
- Verified tooltip shows proper content on hover
- Tested with various node types