### PR TITLE
Fix: Align scan and build commands with identical filtering options

### DIFF
--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -57,6 +57,22 @@ atg scan \
   --generate-spec \
   --visualize
 
+# Scan specific subscriptions only
+atg scan \
+  --filter-by-subscriptions "sub-id-1,sub-id-2" \
+  --no-dashboard
+
+# Scan specific resource groups only
+atg scan \
+  --filter-by-rgs "rg-prod,rg-staging" \
+  --no-dashboard
+
+# Combine subscription and resource group filtering
+atg scan \
+  --filter-by-subscriptions "prod-subscription-id" \
+  --filter-by-rgs "critical-resources-rg,data-rg" \
+  --no-dashboard
+
 # Scan without container auto-start
 atg scan --no-container --no-dashboard
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -457,6 +457,16 @@ async def build(
     is_flag=True,
     help="Disable Azure AD user/group import from Microsoft Graph API",
 )
+@click.option(
+    "--filter-by-subscriptions",
+    type=str,
+    help="Comma-separated list of subscription IDs to include (filters discovery)",
+)
+@click.option(
+    "--filter-by-rgs",
+    type=str,
+    help="Comma-separated list of resource group names to include (filters discovery)",
+)
 @click.pass_context
 @async_command
 async def scan(
@@ -474,6 +484,8 @@ async def scan(
     test_keypress_file: str,
     rebuild_edges: bool = False,
     no_aad_import: bool = False,
+    filter_by_subscriptions: Optional[str] = None,
+    filter_by_rgs: Optional[str] = None,
 ) -> str | None:
     """
     Scan the complete Azure tenant graph with enhanced processing.
@@ -505,6 +517,8 @@ async def scan(
         rebuild_edges,
         no_aad_import,
         debug,
+        filter_by_subscriptions,
+        filter_by_rgs,
     )
     if debug:
         print(f"[DEBUG] scan command (via build_command_handler) returned: {result!r}", flush=True)

--- a/tests/test_scan_build_consistency.py
+++ b/tests/test_scan_build_consistency.py
@@ -1,0 +1,65 @@
+"""Test that scan and build commands have identical options."""
+
+import click
+from click.testing import CliRunner
+from scripts.cli import cli
+
+
+class TestScanBuildConsistency:
+    """Test that scan and build commands are consistent."""
+    
+    def test_scan_and_build_have_same_options(self):
+        """Verify that scan and build commands have identical options."""
+        # Get the commands from the CLI group
+        build_cmd = cli.commands.get('build')
+        scan_cmd = cli.commands.get('scan')
+        
+        assert build_cmd is not None, "build command not found"
+        assert scan_cmd is not None, "scan command not found"
+        
+        # Get option names for each command
+        build_options = {param.name for param in build_cmd.params if isinstance(param, click.Option)}
+        scan_options = {param.name for param in scan_cmd.params if isinstance(param, click.Option)}
+        
+        # Check that both commands have the same options
+        missing_in_scan = build_options - scan_options
+        missing_in_build = scan_options - build_options
+        
+        assert missing_in_scan == set(), f"Options in build but not in scan: {missing_in_scan}"
+        assert missing_in_build == set(), f"Options in scan but not in build: {missing_in_build}"
+        
+    def test_scan_accepts_filter_options(self):
+        """Test that scan command accepts filter options added in PR #229."""
+        runner = CliRunner()
+        
+        # Test --filter-by-subscriptions
+        result = runner.invoke(cli, ['scan', '--help'])
+        assert result.exit_code == 0
+        assert '--filter-by-subscriptions' in result.output, "scan command missing --filter-by-subscriptions option"
+        
+        # Test --filter-by-rgs  
+        assert '--filter-by-rgs' in result.output, "scan command missing --filter-by-rgs option"
+        
+    def test_build_accepts_filter_options(self):
+        """Test that build command has filter options from PR #229."""
+        runner = CliRunner()
+        
+        result = runner.invoke(cli, ['build', '--help'])
+        assert result.exit_code == 0
+        assert '--filter-by-subscriptions' in result.output, "build command missing --filter-by-subscriptions option"
+        assert '--filter-by-rgs' in result.output, "build command missing --filter-by-rgs option"
+        
+    def test_scan_and_build_help_text_consistency(self):
+        """Test that help text is consistent between scan and build."""
+        runner = CliRunner()
+        
+        build_result = runner.invoke(cli, ['build', '--help'])
+        scan_result = runner.invoke(cli, ['scan', '--help'])
+        
+        # Both should mention filtering
+        assert 'filter' in build_result.output.lower() or 'subscription' in build_result.output.lower()
+        assert 'filter' in scan_result.output.lower() or 'subscription' in scan_result.output.lower()
+        
+        # Both should have dashboard options
+        assert '--no-dashboard' in build_result.output
+        assert '--no-dashboard' in scan_result.output


### PR DESCRIPTION
## Summary

This PR fixes issue #249 where the `atg scan` and `atg build` commands had inconsistent options after PR #229.

## Problem

- PR #229 added `--filter-by-subscriptions` and `--filter-by-rgs` options to the `build` command
- These options were not added to the `scan` command, making the commands inconsistent
- The scan command is supposed to be an alias for build with identical functionality

## Solution

- Added the missing filtering options to the `scan` command
- Ensured both commands pass the same parameters to `build_command_handler`
- Added test to verify commands remain consistent
- Updated CLI documentation with filtering examples

## Changes

1. **scripts/cli.py**
   - Added `--filter-by-subscriptions` option to scan command
   - Added `--filter-by-rgs` option to scan command
   - Updated scan function signature to accept filter parameters
   - Pass filter parameters to build_command_handler

2. **CLI_COMMANDS.md**
   - Added examples showing how to use the filtering options
   - Documented both single and combined filter usage

3. **tests/test_scan_build_consistency.py**
   - New test file to ensure scan and build commands have identical options
   - Tests verify both commands accept the same parameters
   - Prevents future divergence between the commands

## Testing

- Verified `atg scan --help` now shows the filtering options
- Verified `atg build --help` continues to show the filtering options
- Added automated test to ensure commands stay synchronized
- Ran linters (ruff) - all checks pass

## Related

- Fixes #249
- Follows up on PR #229

## Checklist

- [x] Code changes complete
- [x] Tests added and passing
- [x] Documentation updated
- [x] Linting passes
- [x] PR created