### PR TITLE
feat: Implement managed identity inclusion for filtered builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,27 @@ azure-tenant-grapher scan --tenant-id <your-tenant-id> --no-aad-import
 
 # Rescan—all relationships will be re-evaluated
 azure-tenant-grapher scan --tenant-id <your-tenant-id> --rebuild-edges
+
+# Scan with filtering by subscriptions (includes referenced identities)
+azure-tenant-grapher scan --tenant-id <your-tenant-id> --filter-by-subscriptions sub1,sub2
+
+# Scan with filtering by resource groups (includes referenced identities)
+azure-tenant-grapher scan --tenant-id <your-tenant-id> --filter-by-rgs rg1,rg2
 ```
+
+### Filtered Scanning with Identity Inclusion
+
+When using `--filter-by-subscriptions` or `--filter-by-rgs` options, Azure Tenant Grapher automatically:
+
+1. **Discovers only resources** matching your filter criteria
+2. **Extracts identity references** from filtered resources:
+   - System-assigned managed identities
+   - User-assigned managed identities  
+   - Users, groups, and service principals from role assignments
+3. **Imports only referenced identities** from Azure AD/Graph API
+4. **Preserves all relationships** between filtered resources and their identities
+
+This ensures your filtered graph contains all necessary identity information without importing the entire Azure AD directory.
 
 ### Azure AD Identity Import
 

--- a/backlog.md
+++ b/backlog.md
@@ -19,24 +19,24 @@ When implementing new features or fixing issues, follow this workflow:
 
 ## Current Issues
 
-### 1.  Fix 'atg scan' and 'atg build' command inconsistency
+### 1. ✅ Fix 'atg scan' and 'atg build' command inconsistency
 **Status**: Completed - PR #256
 - The scan and build commands should be identical (one should be an alias of the other)
 - The help text was different and PR #229 changes didn't appear in atg scan
 - Fixed by adding missing filter options to scan command
 
-### 2.  Improve 'atg generate-spec' organization by resource containment
+### 2. ✅ Improve 'atg generate-spec' organization by resource containment
 **Status**: Completed - PR #257
 - Reorganized output by containment hierarchy
 - Added purpose inference at each level
 - Starts with tenant summary, then subscriptions, regions, resource groups, and resources
 
-### 3. = Fix managed identity inclusion in filtered builds
-**Status**: In Progress
+### 3. ✅ Fix managed identity inclusion in filtered builds
+**Status**: Completed - PR #258
 - When using filters (--filter-by-subscriptions or --filter-by-rgs)
-- Should include referenced managed identities
-- Should include roles/groups assigned to those identities
-- Requires Graph API integration
+- Automatically extracts and includes referenced managed identities
+- Imports only relevant users, groups, and service principals from Graph API
+- Preserves all identity relationships for filtered resources
 
 ## Future Enhancements
 

--- a/src/services/aad_graph_service.py
+++ b/src/services/aad_graph_service.py
@@ -1,12 +1,13 @@
 import logging
 import os
 import time
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 
 from azure.identity import ClientSecretCredential
 from kiota_abstractions.base_request_configuration import RequestConfiguration
 from msgraph.generated.groups.groups_request_builder import GroupsRequestBuilder
 from msgraph.generated.models.o_data_errors.o_data_error import ODataError
+from msgraph.generated.service_principals.service_principals_request_builder import ServicePrincipalsRequestBuilder
 from msgraph.generated.users.users_request_builder import UsersRequestBuilder
 from msgraph.graph_service_client import GraphServiceClient
 
@@ -164,6 +165,59 @@ class AADGraphService:
         result = await self._retry_with_backoff(fetch_users)
         return result if result is not None else []
 
+    async def get_users_by_ids(self, user_ids: Set[str]) -> List[Dict[str, Any]]:
+        """
+        Fetches specific users by their IDs from Microsoft Graph API.
+        
+        Args:
+            user_ids: Set of user IDs to fetch
+            
+        Returns:
+            List of user dictionaries for the specified IDs
+        """
+        if not user_ids:
+            return []
+            
+        if self.use_mock:
+            # Return mock users matching the requested IDs
+            mock_users = [
+                {"id": "mock-user-1", "displayName": "Mock User One"},
+                {"id": "mock-user-2", "displayName": "Mock User Two"},
+            ]
+            return [u for u in mock_users if u["id"] in user_ids]
+            
+        if not self.client:
+            raise RuntimeError("Graph client not initialized")
+            
+        users = []
+        
+        # Fetch each user individually (batch requests could be optimized later)
+        for user_id in user_ids:
+            try:
+                async def fetch_user():
+                    if not self.client:
+                        raise RuntimeError("Graph client not initialized")
+                    user = await self.client.users.by_user_id(user_id).get()
+                    if user:
+                        return {
+                            "id": user.id,
+                            "displayName": user.display_name,
+                            "userPrincipalName": user.user_principal_name,
+                            "mail": user.mail,
+                        }
+                    return None
+                    
+                user_data = await self._retry_with_backoff(fetch_user)
+                if user_data:
+                    users.append(user_data)
+            except ODataError as e:
+                # User not found or no permissions - log and continue
+                logger.warning(f"Could not fetch user {user_id}: {e}")
+                continue
+                
+        logger.info(f"Fetched {len(users)} users out of {len(user_ids)} requested")
+        return users
+
     async def get_groups(self) -> List[Dict[str, Any]]:
         """
         Fetches groups from Microsoft Graph API using SDK, handling pagination and throttling.
@@ -232,6 +286,181 @@ class AADGraphService:
 
         result = await self._retry_with_backoff(fetch_groups)
         return result if result is not None else []
+
+    async def get_groups_by_ids(self, group_ids: Set[str]) -> List[Dict[str, Any]]:
+        """
+        Fetches specific groups by their IDs from Microsoft Graph API.
+        
+        Args:
+            group_ids: Set of group IDs to fetch
+            
+        Returns:
+            List of group dictionaries for the specified IDs
+        """
+        if not group_ids:
+            return []
+            
+        if self.use_mock:
+            # Return mock groups matching the requested IDs
+            mock_groups = [
+                {"id": "mock-group-1", "displayName": "Mock Group One"},
+                {"id": "mock-group-2", "displayName": "Mock Group Two"},
+            ]
+            return [g for g in mock_groups if g["id"] in group_ids]
+            
+        if not self.client:
+            raise RuntimeError("Graph client not initialized")
+            
+        groups = []
+        
+        # Fetch each group individually
+        for group_id in group_ids:
+            try:
+                async def fetch_group():
+                    if not self.client:
+                        raise RuntimeError("Graph client not initialized")
+                    group = await self.client.groups.by_group_id(group_id).get()
+                    if group:
+                        return {
+                            "id": group.id,
+                            "displayName": group.display_name,
+                            "mail": group.mail,
+                            "description": group.description,
+                        }
+                    return None
+                    
+                group_data = await self._retry_with_backoff(fetch_group)
+                if group_data:
+                    groups.append(group_data)
+            except ODataError as e:
+                # Group not found or no permissions - log and continue
+                logger.warning(f"Could not fetch group {group_id}: {e}")
+                continue
+                
+        logger.info(f"Fetched {len(groups)} groups out of {len(group_ids)} requested")
+        return groups
+
+    async def get_service_principals(self) -> List[Dict[str, Any]]:
+        """
+        Fetches all service principals from Microsoft Graph API.
+        Returns a list of service principal dictionaries.
+        """
+        if self.use_mock:
+            return [
+                {"id": "mock-sp-1", "displayName": "Mock Service Principal One"},
+                {"id": "mock-sp-2", "displayName": "Mock Service Principal Two"},
+            ]
+            
+        if not self.client:
+            raise RuntimeError("Graph client not initialized")
+            
+        async def fetch_service_principals():
+            service_principals = []
+            
+            # Configure request
+            query_params = ServicePrincipalsRequestBuilder.ServicePrincipalsRequestBuilderGetQueryParameters(
+                select=["id", "displayName", "appId", "servicePrincipalType"]
+            )
+            request_config = RequestConfiguration(query_parameters=query_params)
+            
+            # Get first page
+            if not self.client:
+                raise RuntimeError("Graph client not initialized")
+            sp_page = await self.client.service_principals.get(
+                request_configuration=request_config
+            )
+            
+            if sp_page and sp_page.value:
+                for sp in sp_page.value:
+                    service_principals.append(
+                        {
+                            "id": sp.id,
+                            "displayName": sp.display_name,
+                            "appId": sp.app_id,
+                            "servicePrincipalType": sp.service_principal_type,
+                        }
+                    )
+            
+            # Handle pagination
+            while sp_page and sp_page.odata_next_link:
+                logger.info(
+                    f"Fetching next page of service principals (current count: {len(service_principals)})"
+                )
+                if not self.client:
+                    raise RuntimeError("Graph client not initialized")
+                sp_page = await self.client.service_principals.with_url(
+                    sp_page.odata_next_link
+                ).get()
+                
+                if sp_page and sp_page.value:
+                    for sp in sp_page.value:
+                        service_principals.append(
+                            {
+                                "id": sp.id,
+                                "displayName": sp.display_name,
+                                "appId": sp.app_id,
+                                "servicePrincipalType": sp.service_principal_type,
+                            }
+                        )
+            
+            logger.info(f"Fetched {len(service_principals)} service principals from Microsoft Graph")
+            return service_principals
+            
+        result = await self._retry_with_backoff(fetch_service_principals)
+        return result if result is not None else []
+
+    async def get_service_principals_by_ids(self, principal_ids: Set[str]) -> List[Dict[str, Any]]:
+        """
+        Fetches specific service principals by their IDs from Microsoft Graph API.
+        
+        Args:
+            principal_ids: Set of service principal IDs to fetch
+            
+        Returns:
+            List of service principal dictionaries for the specified IDs
+        """
+        if not principal_ids:
+            return []
+            
+        if self.use_mock:
+            # Return mock service principals matching the requested IDs
+            mock_sps = [
+                {"id": "mock-sp-1", "displayName": "Mock Service Principal One"},
+                {"id": "mock-sp-2", "displayName": "Mock Service Principal Two"},
+            ]
+            return [sp for sp in mock_sps if sp["id"] in principal_ids]
+            
+        if not self.client:
+            raise RuntimeError("Graph client not initialized")
+            
+        service_principals = []
+        
+        # Fetch each service principal individually
+        for sp_id in principal_ids:
+            try:
+                async def fetch_sp():
+                    if not self.client:
+                        raise RuntimeError("Graph client not initialized")
+                    sp = await self.client.service_principals.by_service_principal_id(sp_id).get()
+                    if sp:
+                        return {
+                            "id": sp.id,
+                            "displayName": sp.display_name,
+                            "appId": sp.app_id,
+                            "servicePrincipalType": sp.service_principal_type,
+                        }
+                    return None
+                    
+                sp_data = await self._retry_with_backoff(fetch_sp)
+                if sp_data:
+                    service_principals.append(sp_data)
+            except ODataError as e:
+                # Service principal not found or no permissions - log and continue
+                logger.warning(f"Could not fetch service principal {sp_id}: {e}")
+                continue
+                
+        logger.info(f"Fetched {len(service_principals)} service principals out of {len(principal_ids)} requested")
+        return service_principals
 
     async def get_group_memberships(self, group_id: str) -> List[Dict[str, Any]]:
         """
@@ -376,3 +605,138 @@ class AADGraphService:
                         )
 
         logger.info("Completed AAD graph ingestion")
+
+    async def ingest_filtered_identities(
+        self,
+        user_ids: Set[str],
+        group_ids: Set[str],
+        service_principal_ids: Set[str],
+        db_ops: Any,
+        dry_run: bool = False
+    ) -> None:
+        """
+        Ingests only specific AAD identities into the graph.
+        Used when filtering resources to include only referenced identities.
+        
+        Args:
+            user_ids: Set of user IDs to ingest
+            group_ids: Set of group IDs to ingest
+            service_principal_ids: Set of service principal IDs to ingest
+            db_ops: DatabaseOperations instance
+            dry_run: If True, skips DB operations (for tests)
+        """
+        logger.info(
+            f"Starting filtered AAD graph ingestion - "
+            f"Users: {len(user_ids)}, Groups: {len(group_ids)}, "
+            f"Service Principals: {len(service_principal_ids)}"
+        )
+        
+        # Fetch identities concurrently
+        import asyncio
+        
+        users, groups, service_principals = await asyncio.gather(
+            self.get_users_by_ids(user_ids),
+            self.get_groups_by_ids(group_ids),
+            self.get_service_principals_by_ids(service_principal_ids)
+        )
+        
+        logger.info(
+            f"Fetched {len(users)} users, {len(groups)} groups, "
+            f"{len(service_principals)} service principals"
+        )
+        
+        # Upsert User nodes
+        for user in users:
+            user_id = user.get("id")
+            if not user_id:
+                continue
+            props = {
+                "id": user_id,
+                "display_name": user.get("displayName"),
+                "user_principal_name": user.get("userPrincipalName"),
+                "mail": user.get("mail"),
+                "type": "User",
+            }
+            if not dry_run:
+                db_ops.upsert_generic("User", "id", user_id, props)
+        
+        # Upsert Group nodes
+        for group in groups:
+            group_id = group.get("id")
+            if not group_id:
+                continue
+            props = {
+                "id": group_id,
+                "display_name": group.get("displayName"),
+                "mail": group.get("mail"),
+                "description": group.get("description"),
+                "type": "IdentityGroup",
+            }
+            if not dry_run:
+                db_ops.upsert_generic("IdentityGroup", "id", group_id, props)
+        
+        # Upsert ServicePrincipal nodes
+        for sp in service_principals:
+            sp_id = sp.get("id")
+            if not sp_id:
+                continue
+            props = {
+                "id": sp_id,
+                "display_name": sp.get("displayName"),
+                "app_id": sp.get("appId"),
+                "service_principal_type": sp.get("servicePrincipalType"),
+                "type": "ServicePrincipal",
+            }
+            if not dry_run:
+                db_ops.upsert_generic("ServicePrincipal", "id", sp_id, props)
+        
+        # Fetch and create group memberships only for the filtered groups
+        for group in groups:
+            group_id = group.get("id")
+            if not group_id:
+                continue
+            
+            logger.info(
+                f"Fetching memberships for group {group_id} ({group.get('displayName', 'Unknown')})"
+            )
+            members = await self.get_group_memberships(str(group_id))
+            
+            for member in members:
+                member_id = member.get("id")
+                if not member_id:
+                    continue
+                    
+                # Only create edge if member is in our filtered sets
+                odata_type = member.get("@odata.type", "")
+                if odata_type.endswith("user") and member_id in user_ids:
+                    # MEMBER_OF: User-[:MEMBER_OF]->IdentityGroup
+                    if not dry_run:
+                        db_ops.create_generic_rel(
+                            src_id=member_id,
+                            rel_type="MEMBER_OF",
+                            tgt_key_value=group_id,
+                            tgt_label="IdentityGroup",
+                            tgt_key_prop="id",
+                        )
+                elif odata_type.endswith("group") and member_id in group_ids:
+                    # MEMBER_OF: IdentityGroup-[:MEMBER_OF]->IdentityGroup
+                    if not dry_run:
+                        db_ops.create_generic_rel(
+                            src_id=member_id,
+                            rel_type="MEMBER_OF",
+                            tgt_key_value=group_id,
+                            tgt_label="IdentityGroup",
+                            tgt_key_prop="id",
+                        )
+                elif odata_type.endswith("servicePrincipal") and member_id in service_principal_ids:
+                    # MEMBER_OF: ServicePrincipal-[:MEMBER_OF]->IdentityGroup
+                    if not dry_run:
+                        db_ops.create_generic_rel(
+                            src_id=member_id,
+                            rel_type="MEMBER_OF",
+                            tgt_key_value=group_id,
+                            tgt_label="IdentityGroup",
+                            tgt_key_prop="id",
+                        )
+        
+        logger.info("Completed filtered AAD graph ingestion")

--- a/src/services/identity_collector.py
+++ b/src/services/identity_collector.py
@@ -1,0 +1,242 @@
+"""Service for collecting identity references from Azure resources."""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IdentityReference:
+    """Reference to an identity found in Azure resources."""
+    
+    id: str
+    type: str  # "User", "ServicePrincipal", "ManagedIdentity", "Group"
+    source_resource_id: Optional[str] = None
+
+
+@dataclass
+class IdentityReferences:
+    """Collection of identity references grouped by type."""
+    
+    users: Set[str] = field(default_factory=set)
+    service_principals: Set[str] = field(default_factory=set)
+    managed_identities: Set[str] = field(default_factory=set)
+    groups: Set[str] = field(default_factory=set)
+    
+    def has_identities(self) -> bool:
+        """Check if any identities have been collected."""
+        return bool(
+            self.users 
+            or self.service_principals 
+            or self.managed_identities 
+            or self.groups
+        )
+    
+    def total_count(self) -> int:
+        """Get total count of unique identities."""
+        return (
+            len(self.users)
+            + len(self.service_principals)
+            + len(self.managed_identities)
+            + len(self.groups)
+        )
+
+
+class IdentityCollector:
+    """Collects identity references from Azure resources."""
+    
+    def __init__(self):
+        """Initialize the identity collector."""
+        logger.debug("IdentityCollector initialized")
+    
+    def collect_identity_references(self, resources: List[Dict[str, Any]]) -> IdentityReferences:
+        """
+        Extract all identity references from resources.
+        
+        Args:
+            resources: List of Azure resource dictionaries
+            
+        Returns:
+            IdentityReferences containing all discovered identities
+        """
+        references = IdentityReferences()
+        
+        for resource in resources:
+            try:
+                # Extract managed identities
+                identity_refs = self.extract_managed_identities(resource)
+                for ref in identity_refs:
+                    if ref.type == "ManagedIdentity":
+                        references.managed_identities.add(ref.id)
+                
+                # Extract role assignment principals
+                principal_refs = self.extract_role_assignment_principals(resource)
+                for ref in principal_refs:
+                    if ref.type == "User":
+                        references.users.add(ref.id)
+                    elif ref.type == "ServicePrincipal":
+                        references.service_principals.add(ref.id)
+                    elif ref.type == "Group":
+                        references.groups.add(ref.id)
+                    elif ref.type == "ManagedIdentity":
+                        references.managed_identities.add(ref.id)
+                        
+            except Exception as e:
+                logger.warning(
+                    f"Error extracting identities from resource {resource.get('id', 'unknown')}: {e}"
+                )
+        
+        logger.info(
+            f"Collected identities - Users: {len(references.users)}, "
+            f"Service Principals: {len(references.service_principals)}, "
+            f"Managed Identities: {len(references.managed_identities)}, "
+            f"Groups: {len(references.groups)}"
+        )
+        
+        return references
+    
+    def extract_managed_identities(self, resource: Dict[str, Any]) -> List[IdentityReference]:
+        """
+        Extract managed identity references from a single resource.
+        
+        Args:
+            resource: Azure resource dictionary
+            
+        Returns:
+            List of IdentityReference objects for managed identities
+        """
+        identities = []
+        resource_id = resource.get("id")
+        
+        # Check for identity block in resource
+        identity = resource.get("identity")
+        if not identity or not isinstance(identity, dict):
+            return identities
+        
+        identity_type = identity.get("type", "")
+        
+        # Handle system-assigned managed identity
+        if identity_type in ["SystemAssigned", "SystemAssigned,UserAssigned"]:
+            principal_id = identity.get("principalId")
+            if principal_id:
+                identities.append(
+                    IdentityReference(
+                        id=principal_id,
+                        type="ManagedIdentity",
+                        source_resource_id=resource_id
+                    )
+                )
+                logger.debug(
+                    f"Found system-assigned identity {principal_id} in resource {resource_id}"
+                )
+        
+        # Handle user-assigned managed identities
+        if identity_type in ["UserAssigned", "SystemAssigned,UserAssigned"]:
+            user_identities = identity.get("userAssignedIdentities", {})
+            if isinstance(user_identities, dict):
+                for identity_resource_id, identity_details in user_identities.items():
+                    # The key is the resource ID of the user-assigned identity
+                    identities.append(
+                        IdentityReference(
+                            id=identity_resource_id,
+                            type="ManagedIdentity",
+                            source_resource_id=resource_id
+                        )
+                    )
+                    
+                    # Some resources also include the principal ID in the details
+                    if isinstance(identity_details, dict):
+                        principal_id = identity_details.get("principalId")
+                        if principal_id:
+                            identities.append(
+                                IdentityReference(
+                                    id=principal_id,
+                                    type="ManagedIdentity",
+                                    source_resource_id=resource_id
+                                )
+                            )
+                    
+                    logger.debug(
+                        f"Found user-assigned identity {identity_resource_id} in resource {resource_id}"
+                    )
+        
+        return identities
+    
+    def extract_role_assignment_principals(self, resource: Dict[str, Any]) -> List[IdentityReference]:
+        """
+        Extract principal IDs from role assignments.
+        
+        Args:
+            resource: Azure resource dictionary
+            
+        Returns:
+            List of IdentityReference objects for principals in role assignments
+        """
+        identities = []
+        resource_id = resource.get("id")
+        resource_type = resource.get("type", "")
+        
+        # Check if this is a role assignment
+        if not resource_type.endswith("roleAssignments"):
+            return identities
+        
+        # Get properties (could be in properties or at root level)
+        props = resource.get("properties", resource)
+        
+        principal_id = props.get("principalId")
+        principal_type = props.get("principalType", "Unknown")
+        
+        if principal_id:
+            # Map Azure principal types to our types
+            type_mapping = {
+                "User": "User",
+                "Group": "Group",
+                "ServicePrincipal": "ServicePrincipal",
+                "ManagedIdentity": "ManagedIdentity",
+                "Application": "ServicePrincipal",  # Applications are service principals
+                "ForeignGroup": "Group",
+                "Unknown": "ServicePrincipal"  # Default to service principal for unknown
+            }
+            
+            identity_type = type_mapping.get(principal_type, "ServicePrincipal")
+            
+            identities.append(
+                IdentityReference(
+                    id=principal_id,
+                    type=identity_type,
+                    source_resource_id=resource_id
+                )
+            )
+            
+            logger.debug(
+                f"Found {identity_type} principal {principal_id} in role assignment {resource_id}"
+            )
+        
+        return identities
+    
+    def get_summary(self, references: IdentityReferences) -> str:
+        """
+        Get a human-readable summary of collected identities.
+        
+        Args:
+            references: IdentityReferences to summarize
+            
+        Returns:
+            String summary of identities
+        """
+        if not references.has_identities():
+            return "No identities found"
+        
+        parts = []
+        if references.users:
+            parts.append(f"{len(references.users)} users")
+        if references.service_principals:
+            parts.append(f"{len(references.service_principals)} service principals")
+        if references.managed_identities:
+            parts.append(f"{len(references.managed_identities)} managed identities")
+        if references.groups:
+            parts.append(f"{len(references.groups)} groups")
+        
+        return f"Found {references.total_count()} identities: {', '.join(parts)}"

--- a/src/services/managed_identity_resolver.py
+++ b/src/services/managed_identity_resolver.py
@@ -1,0 +1,152 @@
+"""Service for resolving managed identity details from Azure."""
+
+import logging
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+class ManagedIdentityResolver:
+    """Resolves managed identity details for both system and user-assigned identities."""
+    
+    def __init__(self, azure_service: Optional[Any] = None):
+        """
+        Initialize the managed identity resolver.
+        
+        Args:
+            azure_service: Optional AzureDataService instance for querying Azure resources
+        """
+        self.azure_service = azure_service
+        logger.debug("ManagedIdentityResolver initialized")
+    
+    def resolve_identities(
+        self,
+        identity_refs: Set[str],
+        all_resources: List[Dict[str, Any]]
+    ) -> Dict[str, Dict[str, Any]]:
+        """
+        Resolve managed identities to their full details.
+        
+        Args:
+            identity_refs: Set of identity IDs or resource IDs to resolve
+            all_resources: List of all Azure resources to search through
+            
+        Returns:
+            Dictionary mapping identity ID to identity details
+        """
+        resolved = {}
+        
+        for resource in all_resources:
+            resource_type = resource.get("type", "")
+            resource_id = resource.get("id", "")
+            
+            # Check if this is a user-assigned managed identity resource
+            if resource_type == "Microsoft.ManagedIdentity/userAssignedIdentities":
+                # The resource ID itself might be in our identity_refs
+                if resource_id in identity_refs:
+                    resolved[resource_id] = {
+                        "id": resource_id,
+                        "type": "UserAssignedManagedIdentity",
+                        "name": resource.get("name"),
+                        "location": resource.get("location"),
+                        "principalId": resource.get("properties", {}).get("principalId"),
+                        "clientId": resource.get("properties", {}).get("clientId"),
+                        "tenantId": resource.get("properties", {}).get("tenantId"),
+                    }
+                    logger.debug(f"Resolved user-assigned identity: {resource_id}")
+                
+                # Also check if the principal ID is in our refs
+                principal_id = resource.get("properties", {}).get("principalId")
+                if principal_id and principal_id in identity_refs:
+                    resolved[principal_id] = {
+                        "id": principal_id,
+                        "resourceId": resource_id,
+                        "type": "UserAssignedManagedIdentity",
+                        "name": resource.get("name"),
+                        "location": resource.get("location"),
+                        "principalId": principal_id,
+                        "clientId": resource.get("properties", {}).get("clientId"),
+                        "tenantId": resource.get("properties", {}).get("tenantId"),
+                    }
+                    logger.debug(f"Resolved user-assigned identity by principal ID: {principal_id}")
+            
+            # Check for system-assigned identities
+            identity = resource.get("identity")
+            if identity and isinstance(identity, dict):
+                identity_type = identity.get("type", "")
+                
+                # System-assigned identity
+                if "SystemAssigned" in identity_type:
+                    principal_id = identity.get("principalId")
+                    if principal_id and principal_id in identity_refs:
+                        resolved[principal_id] = {
+                            "id": principal_id,
+                            "type": "SystemAssignedManagedIdentity",
+                            "resourceId": resource_id,
+                            "resourceType": resource_type,
+                            "resourceName": resource.get("name"),
+                            "principalId": principal_id,
+                            "tenantId": identity.get("tenantId"),
+                        }
+                        logger.debug(
+                            f"Resolved system-assigned identity {principal_id} "
+                            f"from resource {resource_id}"
+                        )
+        
+        logger.info(f"Resolved {len(resolved)} managed identities out of {len(identity_refs)} references")
+        return resolved
+    
+    def extract_additional_references(
+        self,
+        resolved_identities: Dict[str, Dict[str, Any]]
+    ) -> Set[str]:
+        """
+        Extract additional identity references from resolved identities.
+        
+        Some resolved identities might reference other identities that also need to be included.
+        
+        Args:
+            resolved_identities: Dictionary of resolved identity details
+            
+        Returns:
+            Set of additional identity IDs to fetch
+        """
+        additional_refs = set()
+        
+        # Currently, managed identities don't typically reference other identities directly
+        # But this method is here for future extensibility if needed
+        
+        return additional_refs
+    
+    def get_identity_summary(
+        self,
+        resolved_identities: Dict[str, Dict[str, Any]]
+    ) -> str:
+        """
+        Get a human-readable summary of resolved identities.
+        
+        Args:
+            resolved_identities: Dictionary of resolved identity details
+            
+        Returns:
+            String summary of identities
+        """
+        if not resolved_identities:
+            return "No managed identities resolved"
+        
+        system_assigned = 0
+        user_assigned = 0
+        
+        for identity in resolved_identities.values():
+            if identity.get("type") == "SystemAssignedManagedIdentity":
+                system_assigned += 1
+            elif identity.get("type") == "UserAssignedManagedIdentity":
+                user_assigned += 1
+        
+        parts = []
+        if system_assigned:
+            parts.append(f"{system_assigned} system-assigned")
+        if user_assigned:
+            parts.append(f"{user_assigned} user-assigned")
+        
+        return f"Resolved {len(resolved_identities)} managed identities: {', '.join(parts)}"

--- a/src/services/resource_processing_service.py
+++ b/src/services/resource_processing_service.py
@@ -11,6 +11,8 @@ from src.resource_processor import (
     ProcessingStats,
     ResourceProcessor,
 )
+from src.services.identity_collector import IdentityCollector
+from src.services.managed_identity_resolver import ManagedIdentityResolver
 from src.utils.session_manager import Neo4jSessionManager
 
 logger = logging.getLogger(__name__)
@@ -64,29 +66,70 @@ class ResourceProcessingService:
         # Use config value which defaults to True, can be overridden by env var
         enable_aad = getattr(self.config, "enable_aad_import", True)
         
-        # Skip AAD import when filtering by resource groups or subscriptions
-        # Because we can't determine which users/groups are relevant to just those resources
+        # Check if we're filtering resources
         is_filtering = filter_config and (filter_config.has_filters() if hasattr(filter_config, 'has_filters') else 
                                           (filter_config.resource_group_names or filter_config.subscription_ids))
         
-        if enable_aad and self.aad_graph_service and not is_filtering:
-            logger.info(
-                "AAD import enabled: ingesting Azure AD users and groups into graph."
-            )
-            try:
-                await self.aad_graph_service.ingest_into_graph(processor.db_ops)
-            except Exception as ex:
-                logger.exception(f"Failed to ingest AAD users/groups: {ex}")
-        elif is_filtering and enable_aad:
-            logger.info(
-                "⚠️  Skipping AAD user/group import when filtering by subscriptions or resource groups. "
-                "Only resources matching the filter will be imported."
-            )
+        if enable_aad and self.aad_graph_service:
+            if not is_filtering:
+                # No filtering - import all AAD users and groups
+                logger.info(
+                    "AAD import enabled: ingesting all Azure AD users and groups into graph."
+                )
+                try:
+                    await self.aad_graph_service.ingest_into_graph(processor.db_ops)
+                except Exception as ex:
+                    logger.exception(f"Failed to ingest AAD users/groups: {ex}")
+            else:
+                # Filtering enabled - import only referenced identities
+                logger.info(
+                    "🎯 Filtering enabled: extracting and importing only referenced identities."
+                )
+                try:
+                    # Extract identity references from filtered resources
+                    identity_collector = IdentityCollector()
+                    identity_refs = identity_collector.collect_identity_references(resources)
+                    
+                    if identity_refs.has_identities():
+                        logger.info(identity_collector.get_summary(identity_refs))
+                        
+                        # Resolve managed identities to get additional details
+                        identity_resolver = ManagedIdentityResolver()
+                        resolved_identities = identity_resolver.resolve_identities(
+                            identity_refs.managed_identities,
+                            resources
+                        )
+                        
+                        if resolved_identities:
+                            logger.info(identity_resolver.get_identity_summary(resolved_identities))
+                        
+                        # Ingest only the referenced identities
+                        # Note: Managed identities are service principals in Azure AD
+                        service_principal_ids = identity_refs.service_principals.union(identity_refs.managed_identities)
+                        
+                        await self.aad_graph_service.ingest_filtered_identities(
+                            user_ids=identity_refs.users,
+                            group_ids=identity_refs.groups,
+                            service_principal_ids=service_principal_ids,
+                            db_ops=processor.db_ops
+                        )
+                        logger.info("✅ Successfully imported referenced identities")
+                    else:
+                        logger.info(
+                            "No identity references found in filtered resources - skipping AAD import"
+                        )
+                except Exception as ex:
+                    logger.exception(f"Failed to ingest filtered AAD identities: {ex}")
 
         if max_workers is None:
             max_workers = getattr(self.config, "max_concurrency", 5)
         if max_workers is None:
             max_workers = 5
+        elif is_filtering and enable_aad and not self.aad_graph_service:
+            logger.warning(
+                "⚠️  AAD import enabled with filtering but AADGraphService not available. "
+                "Identities referenced by filtered resources will not be imported."
+            )
         logger.info(
             f"[DEBUG][RPS] Calling processor.process_resources with {len(resources)} resources, max_workers={max_workers}"
         )

--- a/tests/test_filtered_identity_inclusion.py
+++ b/tests/test_filtered_identity_inclusion.py
@@ -1,0 +1,423 @@
+"""Integration tests for filtered identity inclusion feature."""
+
+from typing import Any, Dict, List, Set
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models.filter_config import FilterConfig
+from src.services.identity_collector import IdentityCollector, IdentityReferences
+from src.services.managed_identity_resolver import ManagedIdentityResolver
+from src.services.resource_processing_service import ResourceProcessingService
+
+
+class TestIdentityCollector:
+    """Test the IdentityCollector service."""
+    
+    def test_extract_system_assigned_identity(self):
+        """Test extraction of system-assigned managed identity."""
+        resources = [
+            {
+                "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/webapp1",
+                "type": "Microsoft.Web/sites",
+                "identity": {
+                    "type": "SystemAssigned",
+                    "principalId": "principal-123",
+                    "tenantId": "tenant-456"
+                }
+            }
+        ]
+        
+        collector = IdentityCollector()
+        refs = collector.collect_identity_references(resources)
+        
+        assert "principal-123" in refs.managed_identities
+        assert len(refs.managed_identities) == 1
+        assert len(refs.users) == 0
+        assert len(refs.service_principals) == 0
+        assert len(refs.groups) == 0
+    
+    def test_extract_user_assigned_identities(self):
+        """Test extraction of user-assigned managed identities."""
+        resources = [
+            {
+                "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/webapp2",
+                "type": "Microsoft.Web/sites",
+                "identity": {
+                    "type": "UserAssigned",
+                    "userAssignedIdentities": {
+                        "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                            "principalId": "uai-principal-111",
+                            "clientId": "uai-client-111"
+                        },
+                        "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2": {
+                            "principalId": "uai-principal-222",
+                            "clientId": "uai-client-222"
+                        }
+                    }
+                }
+            }
+        ]
+        
+        collector = IdentityCollector()
+        refs = collector.collect_identity_references(resources)
+        
+        # Should extract both the resource IDs and principal IDs
+        assert len(refs.managed_identities) == 4
+        assert "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1" in refs.managed_identities
+        assert "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2" in refs.managed_identities
+        assert "uai-principal-111" in refs.managed_identities
+        assert "uai-principal-222" in refs.managed_identities
+    
+    def test_extract_role_assignment_principals(self):
+        """Test extraction of principals from role assignments."""
+        resources = [
+            {
+                "id": "/subscriptions/sub1/providers/Microsoft.Authorization/roleAssignments/ra1",
+                "type": "Microsoft.Authorization/roleAssignments",
+                "properties": {
+                    "principalId": "user-001",
+                    "principalType": "User",
+                    "roleDefinitionId": "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/contributor"
+                }
+            },
+            {
+                "id": "/subscriptions/sub1/providers/Microsoft.Authorization/roleAssignments/ra2",
+                "type": "Microsoft.Authorization/roleAssignments",
+                "properties": {
+                    "principalId": "sp-002",
+                    "principalType": "ServicePrincipal",
+                    "roleDefinitionId": "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/reader"
+                }
+            },
+            {
+                "id": "/subscriptions/sub1/providers/Microsoft.Authorization/roleAssignments/ra3",
+                "type": "Microsoft.Authorization/roleAssignments",
+                "properties": {
+                    "principalId": "group-003",
+                    "principalType": "Group",
+                    "roleDefinitionId": "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/owner"
+                }
+            }
+        ]
+        
+        collector = IdentityCollector()
+        refs = collector.collect_identity_references(resources)
+        
+        assert "user-001" in refs.users
+        assert "sp-002" in refs.service_principals
+        assert "group-003" in refs.groups
+        assert len(refs.users) == 1
+        assert len(refs.service_principals) == 1
+        assert len(refs.groups) == 1
+        assert len(refs.managed_identities) == 0
+    
+    def test_mixed_identity_extraction(self):
+        """Test extraction from resources with multiple identity types."""
+        resources = [
+            # Web app with system-assigned identity
+            {
+                "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/webapp1",
+                "type": "Microsoft.Web/sites",
+                "identity": {
+                    "type": "SystemAssigned",
+                    "principalId": "system-principal-001"
+                }
+            },
+            # Role assignment for a user
+            {
+                "id": "/subscriptions/sub1/providers/Microsoft.Authorization/roleAssignments/ra1",
+                "type": "Microsoft.Authorization/roleAssignments",
+                "properties": {
+                    "principalId": "user-001",
+                    "principalType": "User"
+                }
+            },
+            # VM with both system and user-assigned identities
+            {
+                "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+                "type": "Microsoft.Compute/virtualMachines",
+                "identity": {
+                    "type": "SystemAssigned,UserAssigned",
+                    "principalId": "system-principal-002",
+                    "userAssignedIdentities": {
+                        "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                            "principalId": "uai-principal-001"
+                        }
+                    }
+                }
+            }
+        ]
+        
+        collector = IdentityCollector()
+        refs = collector.collect_identity_references(resources)
+        
+        assert refs.total_count() == 5
+        assert len(refs.users) == 1
+        assert len(refs.managed_identities) == 4  # 2 system + 1 UAI resource ID + 1 UAI principal
+        
+        summary = collector.get_summary(refs)
+        assert "5 identities" in summary
+        assert "1 users" in summary
+        assert "4 managed identities" in summary
+
+
+class TestManagedIdentityResolver:
+    """Test the ManagedIdentityResolver service."""
+    
+    def test_resolve_user_assigned_identity_by_resource_id(self):
+        """Test resolving user-assigned identity by its resource ID."""
+        identity_refs = {
+            "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+        
+        resources = [
+            {
+                "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+                "name": "identity1",
+                "location": "eastus",
+                "properties": {
+                    "principalId": "uai-principal-001",
+                    "clientId": "uai-client-001",
+                    "tenantId": "tenant-001"
+                }
+            }
+        ]
+        
+        resolver = ManagedIdentityResolver()
+        resolved = resolver.resolve_identities(identity_refs, resources)
+        
+        assert len(resolved) == 1
+        identity_id = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        assert identity_id in resolved
+        assert resolved[identity_id]["type"] == "UserAssignedManagedIdentity"
+        assert resolved[identity_id]["principalId"] == "uai-principal-001"
+        assert resolved[identity_id]["clientId"] == "uai-client-001"
+    
+    def test_resolve_system_assigned_identity(self):
+        """Test resolving system-assigned identity from resource."""
+        identity_refs = {"system-principal-001"}
+        
+        resources = [
+            {
+                "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/webapp1",
+                "type": "Microsoft.Web/sites",
+                "name": "webapp1",
+                "identity": {
+                    "type": "SystemAssigned",
+                    "principalId": "system-principal-001",
+                    "tenantId": "tenant-001"
+                }
+            }
+        ]
+        
+        resolver = ManagedIdentityResolver()
+        resolved = resolver.resolve_identities(identity_refs, resources)
+        
+        assert len(resolved) == 1
+        assert "system-principal-001" in resolved
+        assert resolved["system-principal-001"]["type"] == "SystemAssignedManagedIdentity"
+        assert resolved["system-principal-001"]["resourceId"] == "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Web/sites/webapp1"
+        assert resolved["system-principal-001"]["resourceName"] == "webapp1"
+    
+    def test_get_identity_summary(self):
+        """Test generating human-readable summary of resolved identities."""
+        resolved_identities = {
+            "system-001": {"type": "SystemAssignedManagedIdentity"},
+            "system-002": {"type": "SystemAssignedManagedIdentity"},
+            "uai-001": {"type": "UserAssignedManagedIdentity"},
+        }
+        
+        resolver = ManagedIdentityResolver()
+        summary = resolver.get_identity_summary(resolved_identities)
+        
+        assert "3 managed identities" in summary
+        assert "2 system-assigned" in summary
+        assert "1 user-assigned" in summary
+
+
+@pytest.mark.asyncio
+class TestResourceProcessingServiceWithFiltering:
+    """Test ResourceProcessingService with identity filtering."""
+    
+    async def test_filtered_identity_import(self):
+        """Test that filtered builds import only referenced identities."""
+        # Setup mocks
+        session_manager = MagicMock()
+        llm_generator = None
+        config = MagicMock()
+        config.enable_aad_import = True
+        config.max_concurrency = 5
+        
+        # Mock AADGraphService
+        aad_service = AsyncMock()
+        aad_service.ingest_filtered_identities = AsyncMock()
+        
+        # Create filter config with valid UUIDs
+        filter_config = FilterConfig(
+            subscription_ids={"12345678-1234-1234-1234-123456789012"},
+            resource_group_names={"rg1"}
+        )
+        
+        # Sample resources with identities
+        resources = [
+            {
+                "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Web/sites/webapp1",
+                "type": "Microsoft.Web/sites",
+                "resource_group": "rg1",
+                "identity": {
+                    "type": "SystemAssigned",
+                    "principalId": "system-principal-001"
+                }
+            },
+            {
+                "id": "/subscriptions/12345678-1234-1234-1234-123456789012/providers/Microsoft.Authorization/roleAssignments/ra1",
+                "type": "Microsoft.Authorization/roleAssignments",
+                "properties": {
+                    "principalId": "user-001",
+                    "principalType": "User"
+                }
+            }
+        ]
+        
+        # Mock processor
+        processor_mock = AsyncMock()
+        processor_mock.process_resources = AsyncMock(return_value=MagicMock(
+            total_resources=2,
+            processed=2,
+            successful=2
+        ))
+        processor_mock.db_ops = MagicMock()
+        
+        processor_factory = MagicMock(return_value=processor_mock)
+        
+        # Create service
+        service = ResourceProcessingService(
+            session_manager,
+            llm_generator,
+            config,
+            processor_factory=processor_factory,
+            aad_graph_service=aad_service
+        )
+        
+        # Process resources with filtering
+        await service.process_resources(
+            resources,
+            filter_config=filter_config
+        )
+        
+        # Verify filtered identity import was called
+        aad_service.ingest_filtered_identities.assert_called_once()
+        call_args = aad_service.ingest_filtered_identities.call_args[1]
+        
+        # Should have extracted the user and managed identity
+        assert "user-001" in call_args["user_ids"]
+        # System-assigned identities are actually service principals in Azure AD
+        # The ResourceProcessingService puts them in service_principal_ids
+        assert len(call_args["service_principal_ids"]) == 1
+        assert "system-principal-001" in call_args["service_principal_ids"]
+        assert call_args["db_ops"] == processor_mock.db_ops
+    
+    async def test_no_filtering_imports_all_identities(self):
+        """Test that builds without filtering import all AAD identities."""
+        # Setup mocks
+        session_manager = MagicMock()
+        llm_generator = None
+        config = MagicMock()
+        config.enable_aad_import = True
+        config.max_concurrency = 5
+        
+        # Mock AADGraphService
+        aad_service = AsyncMock()
+        aad_service.ingest_into_graph = AsyncMock()
+        
+        # No filter config
+        filter_config = None
+        
+        resources = [{"id": "resource1"}]
+        
+        # Mock processor
+        processor_mock = AsyncMock()
+        processor_mock.process_resources = AsyncMock(return_value=MagicMock(
+            total_resources=1,
+            processed=1,
+            successful=1
+        ))
+        processor_mock.db_ops = MagicMock()
+        
+        processor_factory = MagicMock(return_value=processor_mock)
+        
+        # Create service
+        service = ResourceProcessingService(
+            session_manager,
+            llm_generator,
+            config,
+            processor_factory=processor_factory,
+            aad_graph_service=aad_service
+        )
+        
+        # Process resources without filtering
+        await service.process_resources(
+            resources,
+            filter_config=filter_config
+        )
+        
+        # Verify full AAD import was called
+        aad_service.ingest_into_graph.assert_called_once_with(processor_mock.db_ops)
+        # Filtered import should NOT be called
+        aad_service.ingest_filtered_identities.assert_not_called()
+    
+    async def test_no_identities_in_filtered_resources(self):
+        """Test handling when filtered resources have no identity references."""
+        # Setup mocks
+        session_manager = MagicMock()
+        llm_generator = None
+        config = MagicMock()
+        config.enable_aad_import = True
+        config.max_concurrency = 5
+        
+        # Mock AADGraphService
+        aad_service = AsyncMock()
+        aad_service.ingest_filtered_identities = AsyncMock()
+        
+        # Create filter config
+        filter_config = FilterConfig(resource_group_names={"rg1"})
+        
+        # Resources without any identities
+        resources = [
+            {
+                "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/storage1",
+                "type": "Microsoft.Storage/storageAccounts",
+                "resource_group": "rg1"
+            }
+        ]
+        
+        # Mock processor
+        processor_mock = AsyncMock()
+        processor_mock.process_resources = AsyncMock(return_value=MagicMock(
+            total_resources=1,
+            processed=1,
+            successful=1
+        ))
+        processor_mock.db_ops = MagicMock()
+        
+        processor_factory = MagicMock(return_value=processor_mock)
+        
+        # Create service
+        service = ResourceProcessingService(
+            session_manager,
+            llm_generator,
+            config,
+            processor_factory=processor_factory,
+            aad_graph_service=aad_service
+        )
+        
+        # Process resources with filtering
+        await service.process_resources(
+            resources,
+            filter_config=filter_config
+        )
+        
+        # Verify filtered identity import was NOT called (no identities to import)
+        aad_service.ingest_filtered_identities.assert_not_called()


### PR DESCRIPTION
## Summary
- Implements automatic extraction and inclusion of identity references when using resource filters
- Ensures filtered graphs contain all necessary identity information without importing entire Azure AD
- Addresses issue #3 from the backlog

## Changes

### New Components
- **IdentityCollector**: Extracts identity references from filtered Azure resources
  - Handles system-assigned managed identities
  - Handles user-assigned managed identities
  - Extracts principals from role assignments
  
- **ManagedIdentityResolver**: Resolves managed identity details
  - Maps identity references to their full details
  - Handles both system and user-assigned identities

### Enhanced Components
- **AADGraphService**: Added selective identity fetching methods
  - `get_users_by_ids()` - Fetch specific users
  - `get_groups_by_ids()` - Fetch specific groups  
  - `get_service_principals()` - Fetch all service principals
  - `get_service_principals_by_ids()` - Fetch specific service principals
  - `ingest_filtered_identities()` - Ingest only referenced identities

- **ResourceProcessingService**: Modified for filter-aware identity import
  - Detects when filtering is active
  - Extracts identity references from filtered resources
  - Imports only referenced identities instead of all AAD

## Testing
- Added comprehensive integration tests in `test_filtered_identity_inclusion.py`
- All 10 new tests passing
- Tests cover identity extraction, resolution, and filtered import scenarios

## Documentation
- Updated README.md with new "Filtered Scanning with Identity Inclusion" section
- Updated backlog.md to mark issue as completed

## How It Works
When using `--filter-by-subscriptions` or `--filter-by-rgs`:

1. **Discovers only resources** matching filter criteria
2. **Extracts identity references** from filtered resources:
   - System-assigned managed identities
   - User-assigned managed identities
   - Users, groups, and service principals from role assignments
3. **Imports only referenced identities** from Azure AD/Graph API
4. **Preserves all relationships** between filtered resources and their identities

This ensures filtered builds contain complete identity context without unnecessary AAD data.

🤖 Generated with [Claude Code](https://claude.ai/code)