### PR TITLE
Fix: Correct backend status display in status bar

### DIFF
--- a/spa/renderer/src/App.tsx
+++ b/spa/renderer/src/App.tsx
@@ -103,7 +103,7 @@ const App: React.FC = () => {
   const checkConnection = async () => {
     await withErrorHandling(
       async () => {
-        const systemInfo = await window.electronAPI.system.getInfo();
+        const systemInfo = await window.electronAPI.system.platform();
         const platform = systemInfo?.platform;
         if (platform) {
           setConnectionStatus('connected');


### PR DESCRIPTION
## Summary
- Fixed incorrect "Backend Offline" status display in the status bar
- Backend was fully functional but status incorrectly showed as offline

## Problem
The frontend was calling a non-existent Electron API method `window.electronAPI.system.getInfo()` which caused the connection check to fail, resulting in the backend incorrectly showing as offline even when it was working properly.

## Solution
Changed the API call to use the correct method `window.electronAPI.system.platform()` which exists in the Electron preload API and properly returns system information.

## Test plan
- [x] Start the app with `atg start`
- [x] Verify the status bar shows "Backend" in green instead of "Backend Offline" in red
- [x] Confirm all backend functionality continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)