### PR TITLE
fix: Terraform IaC generation bugs discovered during dry-run validation

### DIFF
--- a/src/deployment/orchestrator.py
+++ b/src/deployment/orchestrator.py
@@ -23,8 +23,8 @@ def detect_iac_format(iac_dir: Path) -> Optional[IaCFormat]:
     if not iac_dir.exists() or not iac_dir.is_dir():
         return None
 
-    # Check for Terraform files
-    if list(iac_dir.glob("*.tf")):
+    # Check for Terraform files (both .tf and .tf.json)
+    if list(iac_dir.glob("*.tf")) or list(iac_dir.glob("*.tf.json")):
         return "terraform"
 
     # Check for Bicep files


### PR DESCRIPTION
## Summary

Fixed three critical bugs in Terraform emitter discovered during cross-tenant IaC demo dry-run validation.

### Bugs Fixed

1. **Terraform JSON Format Detection**
   - `orchestrator.py` now recognizes `*.tf.json` files in addition to `*.tf`
   - **Before**: "Could not detect IaC format in output/iac"
   - **After**: Correctly identifies Terraform JSON format

2. **VMs Missing `network_interface_ids`** (REQUIRED field)
   - Extract NIC IDs from `properties.networkProfile.networkInterfaces`
   - Generate Terraform references: `${azurerm_network_interface.<name>.id}`
   - **Before**: Terraform plan error: "Missing required argument network_interface_ids"
   - **After**: All 15 VMs have valid NIC references

3. **NICs Missing `ip_configuration` Blocks** (REQUIRED field)
   - Parse `properties.ipConfigurations` to extract subnet and IP info
   - Generate `ip_configuration` with name, subnet_id, allocation method
   - Support Static and Dynamic IP allocation
   - **Before**: Terraform plan error: "At least 1 ip_configuration blocks are required"
   - **After**: All 18 NICs have valid IP configuration

4. **Invalid Resource Type Fallback**
   - Replace non-existent `azurerm_generic_resource` with skip + warning
   - Log clear message for unsupported resource types
   - **Before**: 34× "Invalid resource type azurerm_generic_resource"
   - **After**: 34 resources skipped with clear warnings

## Testing

- ✅ Dry-run validation with SimuLand RG (90 resources)
- ✅ Fixed all VM network_interface_ids errors (15 VMs)
- ✅ Fixed all NIC ip_configuration errors (18 NICs)  
- ✅ Eliminated invalid resource type errors (34 resources)
- ⚠️  Remaining issue: Subnet generation (tracked separately)

## Impact

- **Before**: 90 resources → Terraform plan fails with 85+ errors
- **After**: 56 valid resources generated, 34 skipped with warnings
- **Next**: Subnet extraction from vnet properties (in progress)

## Files Changed

- `src/deployment/orchestrator.py`: Terraform JSON format detection
- `src/iac/emitters/terraform_emitter.py`: VM/NIC generation + resource type handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)