### PR TITLE
fix(iac): implement VNet-scoped subnet naming to prevent resource collision (#332)

### DIFF
--- a/test_issue_332.py
+++ b/test_issue_332.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Quick test to verify Issue #332 fix works."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from src.iac.emitters.terraform_emitter import TerraformEmitter
+from src.iac.traverser import TenantGraph
+
+
+def create_vnet(name: str, subnet_names: list) -> dict:
+    """Create mock VNet resource."""
+    subnets = [
+        {
+            "name": subnet_name,
+            "properties": {"addressPrefix": f"10.0.{i}.0/24"}
+        }
+        for i, subnet_name in enumerate(subnet_names)
+    ]
+
+    return {
+        "id": f"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/{name}",
+        "name": name,
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "eastus",
+        "resourceGroup": "test-rg",
+        "address_space": ["10.0.0.0/16"],
+        "properties": json.dumps({
+            "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
+            "subnets": subnets
+        })
+    }
+
+
+def test_vnet_scoped_naming():
+    """Test VNet-scoped subnet naming works."""
+    emitter = TerraformEmitter()
+
+    # Create two VNets with identically-named subnets
+    vnet1 = create_vnet("infra-vnet", ["AzureBastionSubnet"])
+    vnet2 = create_vnet("attack-vnet", ["AzureBastionSubnet"])
+
+    graph = TenantGraph()
+    graph.resources = [vnet1, vnet2]
+
+    # Generate Terraform
+    with tempfile.TemporaryDirectory() as temp_dir:
+        out_dir = Path(temp_dir)
+        emitter.emit(graph, out_dir)
+
+        with open(out_dir / "main.tf.json") as f:
+            config = json.load(f)
+
+    # Verify two distinct subnet resources exist
+    subnets = config["resource"]["azurerm_subnet"]
+
+    print(f"Generated subnets: {list(subnets.keys())}")
+
+    assert "infra_vnet_AzureBastionSubnet" in subnets, \
+        "Should have VNet-scoped subnet: infra_vnet_AzureBastionSubnet"
+    assert "attack_vnet_AzureBastionSubnet" in subnets, \
+        "Should have VNet-scoped subnet: attack_vnet_AzureBastionSubnet"
+    assert len(subnets) == 2, \
+        f"Expected 2 distinct subnets, got {len(subnets)}"
+
+    # Verify Azure names are preserved
+    assert subnets["infra_vnet_AzureBastionSubnet"]["name"] == "AzureBastionSubnet"
+    assert subnets["attack_vnet_AzureBastionSubnet"]["name"] == "AzureBastionSubnet"
+
+    # Verify VNet references are correct
+    assert "infra_vnet" in subnets["infra_vnet_AzureBastionSubnet"]["virtual_network_name"]
+    assert "attack_vnet" in subnets["attack_vnet_AzureBastionSubnet"]["virtual_network_name"]
+
+    print("✓ All tests passed!")
+    return True
+
+
+if __name__ == "__main__":
+    test_vnet_scoped_naming()


### PR DESCRIPTION
## Summary

Fixes #332 - Implements VNet-scoped subnet naming in Terraform IaC generation to prevent resource name collision when multiple VNets contain identically-named subnets (e.g., AzureBastionSubnet).

### Problem
When multiple VNets had subnets with the same name (like "AzureBastionSubnet"), the generated Terraform used only the subnet name as the resource identifier, causing dictionary key collision. Only ONE subnet resource would be created, leading to multiple Bastion Hosts referencing the same subnet and causing Azure deployment error: `MultipleBastionHostNotAllowedInVnet`.

### Solution
Implemented VNet-scoped subnet resource naming pattern: `{vnet_name}_{subnet_name}` for Terraform resource identifiers, while preserving original Azure subnet names in the `name` field.

**Before:**
```
azurerm_subnet.AzureBastionSubnet  # Collision!
```

**After:**
```
azurerm_subnet.infra_vnet_AzureBastionSubnet
azurerm_subnet.attack_vnet_AzureBastionSubnet
```

## Changes Made

### 1. Added Bastion Host Support
- Added `"Microsoft.Network/bastionHosts": "azurerm_bastion_host"` to resource type mapping
- Implemented complete Bastion Host resource processing

### 2. Created Helper Method
- Added `_resolve_subnet_reference()` method for consistent subnet reference resolution
- Extracts both VNet and subnet names from Azure resource IDs
- Constructs VNet-scoped Terraform references
- Includes graceful fallback for malformed IDs with comprehensive logging

### 3. Updated VNet-Embedded Subnet Generation
- Changed subnet resource naming from `{subnet_name}` to `{vnet_name}_{subnet_name}`
- Preserved original Azure names in `name` field
- Added detailed debug logging

### 4. Updated Bastion Host Subnet References
- Replaced manual extraction logic with `_resolve_subnet_reference()` helper
- Added validation warnings for invalid references

### 5. Updated NIC Subnet References
- Replaced manual extraction logic with `_resolve_subnet_reference()` helper
- Added validation warnings for invalid references

### 6. Updated Standalone Subnet Processing
- Implemented VNet-scoped naming for standalone subnet resources
- Added fallback for subnets without parent VNet in ID

## Testing

### Verification Test
Created `test_issue_332.py` to verify the fix:
- Two VNets with identically-named subnets generate distinct Terraform resources
- Azure names are preserved correctly
- VNet references are correct
- **Result:** All tests passed

### Example Output
```
Generated subnets: ['infra_vnet_AzureBastionSubnet', 'attack_vnet_AzureBastionSubnet']
✓ All tests passed!
```

## Impact

- **Backward Compatible**: Unique subnet names still work (just get scoped names)
- **No Breaking Changes**: All names remain valid Terraform identifiers
- **Fixes Critical Bug**: Prevents Bastion Host deployment failures
- **Improved Reliability**: Eliminates subnet resource collision across VNets

## Files Modified
- `src/iac/emitters/terraform_emitter.py` (+243/-17 lines)
- `test_issue_332.py` (new verification test)

## Test Plan

- [x] Unit test created and passing
- [x] Pre-commit hooks passing
- [x] Conventional commit created
- [ ] Full test suite to run in CI
- [ ] Terraform validation with demo topology

🤖 Generated with [Claude Code](https://claude.com/claude-code)