### PR TITLE
fix: Change @gadugi/agentic-test from SSH to HTTPS

### DIFF
--- a/spa/package.json
+++ b/spa/package.json
@@ -66,7 +66,7 @@
     "xterm": "^5.3.0"
   },
   "devDependencies": {
-    "@gadugi/agentic-test": "github:rysweet/gadugi-agentic-test#main",
+    "@gadugi/agentic-test": "https://github.com/rysweet/gadugi-agentic-test.git#main",
     "@playwright/test": "^1.40.0",
     "@testing-library/jest-dom": "^6.1.0",
     "@testing-library/react": "^14.1.0",


### PR DESCRIPTION
Fixes npm install hangs by using HTTPS URL instead of SSH. Root cause of atg start timeout issue.