### PR TITLE
Fix: Allow subscription-scoped resources without location/resource_group

### DIFF
--- a/src/resource_processor.py
+++ b/src/resource_processor.py
@@ -250,14 +250,27 @@ class DatabaseOperations:
 
         try:
             # Defensive validation of required fields
+            # Subscription-scoped resources (e.g., role assignments) don't have location/resource_group
+            subscription_scoped_types = [
+                "Microsoft.Authorization/roleAssignments",
+                "Microsoft.Authorization/roleDefinitions",
+                "Microsoft.Authorization/policyAssignments",
+                "Microsoft.Authorization/policyDefinitions",
+            ]
+
+            is_subscription_scoped = resource.get("type") in subscription_scoped_types
+
             required_fields = [
                 "id",
                 "name",
                 "type",
-                "location",
-                "resource_group",
                 "subscription_id",
             ]
+
+            # Only require location and resource_group for resource-group-scoped resources
+            if not is_subscription_scoped:
+                required_fields.extend(["location", "resource_group"])
+
             # Accept id from resource_id if present
             if not resource.get("id") and resource.get("resource_id"):
                 resource["id"] = resource["resource_id"]


### PR DESCRIPTION
## Problem
Role assignments discovered in PR #381 were failing to be stored in Neo4j due to validation errors. The resource processor required `location` and `resource_group` fields for ALL resources, but subscription-scoped resources (role assignments, role definitions, policies) don't have these fields.

## Solution
Made `location` and `resource_group` conditionally required based on resource scope:
- Subscription-scoped resources: Only require `id`, `name`, `type`, `subscription_id`
- Resource-group-scoped resources: Also require `location` and `resource_group`

## Changes
- Added `subscription_scoped_types` list identifying resources that don't have RG/location
- Modified validation logic to conditionally require fields based on resource type
- Supports: roleAssignments, roleDefinitions, policyAssignments, policyDefinitions

## Testing
- Local scan of ReplicationRG with 902 role assignments discovered
- All role assignments now successfully stored in Neo4j
- No regression for regular resource-group-scoped resources

## Impact
Fixes #381 (role assignment discovery end-to-end)
Unblocks #377 (ReplicationRG replication requires role assignment data)

Generated with [Claude Code](https://claude.com/claude-code)