### PR TITLE
fix: Make AAD Graph service import conditional to respect --no-aad-import flag

### DIFF
--- a/src/azure_tenant_grapher.py
+++ b/src/azure_tenant_grapher.py
@@ -50,7 +50,6 @@ class AzureTenantGrapher:
                 logger.warning(
                     "Migration runner failed or unavailable; skipping migrations."
                 )
-        from .services.aad_graph_service import AADGraphService
         from .services.azure_discovery_service import AzureDiscoveryService
         from .services.resource_processing_service import ResourceProcessingService
         from .services.tenant_specification_service import TenantSpecificationService
@@ -63,10 +62,19 @@ class AzureTenantGrapher:
         aad_graph_service = None
         if config.processing.enable_aad_import:
             try:
+                from .services.aad_graph_service import AADGraphService
                 aad_graph_service = AADGraphService()
                 logger.info("AAD Graph Service initialized for identity import")
+            except ModuleNotFoundError as e:
+                logger.warning(
+                    f"AAD import is enabled but required dependencies are not installed: {e}\n"
+                    "Install msgraph dependencies with: pip install msgraph-sdk azure-identity\n"
+                    "Or disable AAD import with: --no-aad-import"
+                )
+                aad_graph_service = None
             except Exception as e:
                 logger.warning(f"Failed to initialize AAD Graph Service: {e}")
+                aad_graph_service = None
 
         self.processing_service = ResourceProcessingService(
             self.session_manager,


### PR DESCRIPTION
## Problem
Fixes #390

- AAD Graph service was imported unconditionally at module load time in `azure_tenant_grapher.py:53`
- `--no-aad-import` flag had no effect
- `ModuleNotFoundError` blocked scans even when AAD import was disabled
- Prevented ReplicationRG cross-tenant replication demo from running

## Solution
- Move AAD import inside conditional block (`src/azure_tenant_grapher.py:65`)
- Add specific `ModuleNotFoundError` handling with helpful error message
- Add explicit None assignments for clarity
- Follow architect agent's design for ruthless simplicity

## Testing
- ✅ Tested scan with `--no-aad-import` flag - works without msgraph dependencies
- ✅ Import error no longer blocks execution
- ✅ Backward compatible - no changes for users with AAD enabled

## Impact
- Unblocks ReplicationRG cross-tenant replication demo
- Users can disable AAD without installing msgraph dependencies
- Clear error messages guide users on dependency installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)