### PR TITLE
fix: Disable NameConflictValidator validation (not implemented)

### DIFF
--- a/src/iac/cli_handler.py
+++ b/src/iac/cli_handler.py
@@ -454,7 +454,11 @@ async def generate_iac_command_handler(
         paths = emitter.emit(graph, out_dir, **emit_kwargs)
 
         # Validate and fix global name conflicts (GAP-014)
-        if format_type.lower() == "terraform" and not skip_name_validation:
+        # TODO: NameConflictValidator not yet implemented - see Problem 6
+        # Commenting out until class is implemented to avoid ImportError
+        # The validation code below is disabled because NameConflictValidator doesn't exist
+        # To re-enable: implement NameConflictValidator in src/validation/ or use --skip-name-validation flag
+        if False:  # Disabled - NameConflictValidator not implemented
             from ..validation import NameConflictValidator
 
             logger.info("🔍 Checking for global resource name conflicts...")


### PR DESCRIPTION
Fixes Problem 6 from iteration_manual_1 demo.

**Problem:** ImportError when importing non-existent NameConflictValidator class

**Solution:** Wrapped validation code in `if False:` block until class is implemented

**Non-blocking:** Terraform generation completes before this validation runs

See: demos/iteration_manual_1/PROBLEMS.md