### PR TITLE
fix: Use target subscription for provider registration

### DIFF
--- a/src/iac/cli_handler.py
+++ b/src/iac/cli_handler.py
@@ -1008,12 +1008,14 @@ async def generate_iac_command_handler(
             click.echo(f"  📄 {path}")
 
         # Check Azure resource provider registration (before validation/deployment)
-        if format_type.lower() == "terraform" and subscription_id and not dry_run:
+        # Use target_subscription if provided (cross-tenant), otherwise use source subscription
+        provider_check_subscription = target_subscription if target_subscription else subscription_id
+        if format_type.lower() == "terraform" and provider_check_subscription and not dry_run:
             from .provider_manager import ProviderManager
 
             try:
-                logger.info("Checking Azure resource provider registration...")
-                provider_manager = ProviderManager(subscription_id=subscription_id)
+                logger.info(f"Checking Azure resource provider registration in subscription {provider_check_subscription}...")
+                provider_manager = ProviderManager(subscription_id=provider_check_subscription)
                 provider_report = await provider_manager.validate_before_deploy(
                     terraform_path=out_dir,
                     auto_register=auto_register_providers,


### PR DESCRIPTION
## Summary

Fixes critical bug where provider registration was happening in source subscription instead of target subscription during cross-tenant deployments.

## Problem

When using `--auto-register-providers` with cross-tenant deployment:
- Providers were being registered in SOURCE subscription
- But deployment happens in TARGET subscription
- Result: Providers not registered where needed
- Impact: 1,720+ "MissingSubscriptionRegistration" errors

## Root Cause

Line 1016 in cli_handler.py:
```python
provider_manager = ProviderManager(subscription_id=subscription_id)
```

Used `subscription_id` (source) instead of `target_subscription` (target).

## Solution

Use target subscription for provider checks/registration:
```python
provider_check_subscription = target_subscription if target_subscription else subscription_id
provider_manager = ProviderManager(subscription_id=provider_check_subscription)
```

## Impact

**Before**: Providers registered in wrong subscription, deployment fails
**After**: Providers registered in target subscription, `--auto-register-providers` works

**Solves**: "provider not registered errors will happen all the time because we will be using new tenants over and over"

This is THE generalized solution for provider registration across all future deployments to new tenants.

## Testing

Will test by regenerating IaC with this fix and deploying to verify providers auto-register in target subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)