### PR TITLE
fix: Connect Neo4j session manager in smart import workflow (Bug #5)

### DIFF
--- a/src/iac/cli_handler.py
+++ b/src/iac/cli_handler.py
@@ -497,6 +497,7 @@ async def generate_iac_command_handler(
                     from src.utils.session_manager import Neo4jSessionManager
 
                     neo4j = Neo4jSessionManager(config=discovery_config)
+                    await neo4j.connect()
                     comparator = ResourceComparator(neo4j)
 
                     logger.info("Comparing abstracted graph with target scan")


### PR DESCRIPTION
## Summary
Fixes Bug #5: ResourceComparator Neo4j connection errors preventing imports.tf generation

## Problem
The `ResourceComparator` in the smart import workflow was creating a `Neo4jSessionManager` instance but never calling `await neo4j.connect()`. This caused thousands of "is_connected=False" errors during resource comparison, silently falling back to standard generation without creating imports.tf.

## Solution
Added `await neo4j.connect()` after creating the Neo4jSessionManager instance (line 500 in cli_handler.py).

## Testing
- All smart import tests passing
- Verified Neo4j connection established before comparison
- Part of smart import feature implementation (Issue #450)

## Related
- Issue #450
- PR #453 (Smart import core implementation)
- PR #454 (Integration bugs #1 & #2)
- PR #455 (Target credentials bug #3)
- Direct commit 46b513d (Import path bug #4)

**Bug Timeline**:
1. Bug #1: AzureDiscoveryService init ✅ Fixed (PR #454)
2. Bug #2: Name conflict validator blocking ✅ Fixed (PR #454)
3. Bug #3: Wrong tenant credentials ✅ Fixed (PR #455)
4. Bug #4: Neo4jSessionManager import path ✅ Fixed (direct commit)
5. Bug #5: Neo4j not connected ⏳ **This PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)