### PR TITLE
fix: Add missing relationship types to whitelist (Issue #479)

### DIFF
--- a/src/relationship_rules/relationship_rule.py
+++ b/src/relationship_rules/relationship_rule.py
@@ -34,6 +34,11 @@ class RelationshipRule(ABC):
         "TAGGED_WITH",
         "LOCATED_IN",
         "CREATED_BY",
+        "SENDS_DIAG_TO",
+        "ASSIGNED_TO",
+        "HAS_ROLE",
+        "INHERITS_TAG",
+        "STORES_SECRET",
     }
 
     def __init__(self, enable_dual_graph: bool = False):


### PR DESCRIPTION
## Summary
- Adds 5 missing relationship types to VALID_RELATIONSHIP_TYPES whitelist
- Fixes runtime failures when rules create relationships in dual-graph mode

## Changes
- Added `SENDS_DIAG_TO` (DiagnosticRule)
- Added `ASSIGNED_TO` (IdentityRule)
- Added `HAS_ROLE` (IdentityRule)
- Added `INHERITS_TAG` (TagRule)
- Added `STORES_SECRET` (SecretRule)

## Test plan
- [x] Verified all 5 types are now in whitelist
- [x] Diagnostic rule test passes

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)