### PR TITLE
fix: SecretRule broken API - use correct method signatures (Issue #478)

### DIFF
--- a/src/relationship_rules/__init__.py
+++ b/src/relationship_rules/__init__.py
@@ -5,6 +5,7 @@ from .identity_rule import IdentityRule
 from .monitoring_rule import MonitoringRule
 from .network_rule_optimized import NetworkRuleOptimized
 from .region_rule import RegionRule
+from .secret_rule import SecretRule
 from .subnet_extraction_rule import SubnetExtractionRule
 from .tag_rule import TagRule
 
@@ -28,6 +29,7 @@ def create_relationship_rules():
         MonitoringRule(enable_dual_graph=True),
         DiagnosticRule(enable_dual_graph=True),
         DependsOnRule(enable_dual_graph=True),
+        SecretRule(enable_dual_graph=True),  # KeyVault secrets (Issue #478)
     ]
 
 

--- a/src/relationship_rules/secret_rule.py
+++ b/src/relationship_rules/secret_rule.py
@@ -1,3 +1,19 @@
+"""
+SecretRule - Handles KeyVault secret relationships in the graph.
+
+This rule processes Microsoft.KeyVault/vaults resources and creates:
+1. KeyVaultSecret nodes for each discovered secret
+2. STORES_SECRET relationships from KeyVault to KeyVaultSecret nodes
+
+Supports dual-graph architecture - creates relationships in both original
+and abstracted graphs. KeyVaultSecret nodes are shared between graphs
+(not duplicated).
+
+Issue #478: Fixed broken API - was using non-existent create_node() and
+create_relationship() methods. Now uses upsert_generic() and
+create_dual_graph_generic_rel() as per the standard pattern.
+"""
+
 from typing import Any, Dict
 
 from .relationship_rule import RelationshipRule
@@ -6,32 +22,78 @@ from .relationship_rule import RelationshipRule
 class SecretRule(RelationshipRule):
     """
     Handles the STORES_SECRET relationship between KeyVault and KeyVaultSecret nodes.
+
+    Creates KeyVaultSecret nodes for each secret discovered in a KeyVault resource
+    and links them via STORES_SECRET relationships.
+
+    Supports dual-graph architecture - creates relationships in both original
+    and abstracted graphs. KeyVaultSecret nodes are shared between graphs.
     """
 
     def applies(self, resource: Dict[str, Any]) -> bool:
+        """
+        Check if this rule applies to the given resource.
+
+        Args:
+            resource: Resource dictionary from Azure discovery.
+
+        Returns:
+            True if resource is a KeyVault with discovered secrets.
+        """
         # This rule applies to KeyVault resources that have discovered secrets
+        # Empty secrets list should return False (no work to do)
+        secrets = resource.get("secrets", [])
         return (
             resource.get("type") == "Microsoft.KeyVault/vaults"
-            and "secrets" in resource
+            and isinstance(secrets, list)
+            and len(secrets) > 0
         )
 
     def emit(self, resource: Dict[str, Any], db_ops: Any) -> None:
+        """
+        Emit KeyVaultSecret nodes and STORES_SECRET relationships.
+
+        For each secret in the KeyVault:
+        1. Creates/updates a KeyVaultSecret node with name and contentType
+        2. Creates STORES_SECRET relationship from KeyVault to KeyVaultSecret
+
+        Note: Secret values are NEVER stored in the graph for security.
+
+        Args:
+            resource: KeyVault resource dictionary with secrets list.
+            db_ops: DatabaseOperations instance for graph operations.
+        """
         keyvault_id = resource.get("id")
         secrets = resource.get("secrets", [])
+
         for secret in secrets:
             secret_name = secret.get("name")
+            if not secret_name:
+                continue
+
             content_type = secret.get("contentType")
-            # Create KeyVaultSecret node (no value stored)
-            db_ops.create_node(
-                "KeyVaultSecret", {"name": secret_name, "contentType": content_type}
+
+            # Create/update KeyVaultSecret node (no value stored for security)
+            # Uses upsert_generic as per standard pattern (TagRule, RegionRule, etc.)
+            db_ops.upsert_generic(
+                "KeyVaultSecret",
+                "name",
+                secret_name,
+                {
+                    "name": secret_name,
+                    "contentType": content_type,
+                    "keyVaultId": keyvault_id,  # Reference to parent KeyVault
+                },
             )
-            # Create STORES_SECRET relationship
-            db_ops.create_relationship(
-                from_label="KeyVault",
-                from_key="id",
-                from_value=keyvault_id,
-                to_label="KeyVaultSecret",
-                to_key="name",
-                to_value=secret_name,
-                rel_type="STORES_SECRET",
-            )
+
+            # Create STORES_SECRET relationship from KeyVault to KeyVaultSecret
+            # Uses dual-graph helper to create in both original and abstracted graphs
+            if keyvault_id:
+                self.create_dual_graph_generic_rel(
+                    db_ops,
+                    str(keyvault_id),
+                    "STORES_SECRET",
+                    secret_name,
+                    "KeyVaultSecret",
+                    "name",
+                )

--- a/tests/test_secret_rule.py
+++ b/tests/test_secret_rule.py
@@ -1,0 +1,208 @@
+"""
+Tests for SecretRule - KeyVault secret relationship handling.
+
+These tests verify that SecretRule correctly:
+1. Applies to KeyVault resources with secrets
+2. Creates KeyVaultSecret nodes via upsert_generic
+3. Creates STORES_SECRET relationships via dual-graph API
+4. Supports dual-graph architecture
+
+Issue #478: Fix broken SecretRule API
+"""
+
+from src.relationship_rules.secret_rule import SecretRule
+
+
+class DummyDbOps:
+    """Mock database operations for testing.
+
+    Uses the same mock pattern as test_relationship_rules.py to test
+    rule behavior with legacy-mode fallback (session_manager=None).
+    """
+
+    def __init__(self):
+        self.calls = []
+        # Mock session manager for batching support
+        # None triggers legacy mode fallback in base class
+        self.session_manager = None
+
+    def create_generic_rel(self, src, rel, tgt, tgt_label, tgt_key):
+        """Record relationship creation calls."""
+        self.calls.append(("rel", src, rel, tgt, tgt_label, tgt_key))
+
+    def upsert_generic(self, label, key, value, props):
+        """Record node upsert calls."""
+        self.calls.append(("upsert", label, key, value, props))
+
+
+def test_secret_rule_applies_to_keyvault_with_secrets():
+    """SecretRule should apply to KeyVault resources that have secrets."""
+    # Note: Using legacy mode (no dual_graph) for unit tests with mock db_ops
+    # Matches pattern from test_relationship_rules.py
+    rule = SecretRule()
+
+    # Should apply: KeyVault with secrets
+    resource_with_secrets = {
+        "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/kv1",
+        "type": "Microsoft.KeyVault/vaults",
+        "name": "kv1",
+        "secrets": [{"name": "secret1", "contentType": "application/json"}],
+    }
+    assert rule.applies(resource_with_secrets) is True
+
+    # Should NOT apply: KeyVault without secrets
+    resource_no_secrets = {
+        "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/kv2",
+        "type": "Microsoft.KeyVault/vaults",
+        "name": "kv2",
+    }
+    assert rule.applies(resource_no_secrets) is False
+
+    # Should NOT apply: Non-KeyVault resource with "secrets" key
+    non_keyvault = {
+        "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/sa1",
+        "type": "Microsoft.Storage/storageAccounts",
+        "secrets": [{"name": "secret1"}],
+    }
+    assert rule.applies(non_keyvault) is False
+
+
+def test_secret_rule_creates_keyvaultsecret_nodes():
+    """SecretRule should create KeyVaultSecret nodes for each secret."""
+    rule = SecretRule()
+    db = DummyDbOps()
+
+    resource = {
+        "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/kv1",
+        "type": "Microsoft.KeyVault/vaults",
+        "name": "kv1",
+        "secrets": [
+            {"name": "db-password", "contentType": "text/plain"},
+            {"name": "api-key", "contentType": "application/json"},
+        ],
+    }
+
+    rule.emit(resource, db)
+
+    # Verify KeyVaultSecret nodes are created via upsert_generic
+    secret1_call = (
+        "upsert",
+        "KeyVaultSecret",
+        "name",
+        "db-password",
+        {
+            "name": "db-password",
+            "contentType": "text/plain",
+            "keyVaultId": resource["id"],
+        },
+    )
+    secret2_call = (
+        "upsert",
+        "KeyVaultSecret",
+        "name",
+        "api-key",
+        {
+            "name": "api-key",
+            "contentType": "application/json",
+            "keyVaultId": resource["id"],
+        },
+    )
+
+    assert secret1_call in db.calls, f"Expected {secret1_call} in {db.calls}"
+    assert secret2_call in db.calls, f"Expected {secret2_call} in {db.calls}"
+
+
+def test_secret_rule_creates_stores_secret_relationships():
+    """SecretRule should create STORES_SECRET relationships from KeyVault to secrets."""
+    rule = SecretRule()
+    db = DummyDbOps()
+
+    keyvault_id = (
+        "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/kv1"
+    )
+    resource = {
+        "id": keyvault_id,
+        "type": "Microsoft.KeyVault/vaults",
+        "name": "kv1",
+        "secrets": [
+            {"name": "connection-string", "contentType": "text/plain"},
+        ],
+    }
+
+    rule.emit(resource, db)
+
+    # Verify STORES_SECRET relationship is created
+    expected_rel = (
+        "rel",
+        keyvault_id,
+        "STORES_SECRET",
+        "connection-string",
+        "KeyVaultSecret",
+        "name",
+    )
+    assert expected_rel in db.calls, f"Expected {expected_rel} in {db.calls}"
+
+
+def test_secret_rule_handles_empty_secrets_list():
+    """SecretRule should handle empty secrets list gracefully."""
+    rule = SecretRule()
+
+    resource = {
+        "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/kv1",
+        "type": "Microsoft.KeyVault/vaults",
+        "name": "kv1",
+        "secrets": [],
+    }
+
+    # Should not apply if secrets list is empty
+    assert rule.applies(resource) is False
+
+
+def test_secret_rule_handles_secrets_without_content_type():
+    """SecretRule should handle secrets without contentType property."""
+    rule = SecretRule()
+    db = DummyDbOps()
+
+    resource = {
+        "id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/kv1",
+        "type": "Microsoft.KeyVault/vaults",
+        "name": "kv1",
+        "secrets": [
+            {"name": "secret-no-content-type"},
+        ],
+    }
+
+    rule.emit(resource, db)
+
+    # Should create node with None contentType
+    expected_upsert = (
+        "upsert",
+        "KeyVaultSecret",
+        "name",
+        "secret-no-content-type",
+        {
+            "name": "secret-no-content-type",
+            "contentType": None,
+            "keyVaultId": resource["id"],
+        },
+    )
+    assert expected_upsert in db.calls
+
+
+def test_secret_rule_is_registered():
+    """SecretRule should be registered in create_relationship_rules."""
+    from src.relationship_rules import create_relationship_rules
+
+    rules = create_relationship_rules()
+    rule_types = [type(r).__name__ for r in rules]
+
+    assert "SecretRule" in rule_types, f"SecretRule not found in {rule_types}"
+
+
+def test_secret_rule_supports_dual_graph():
+    """SecretRule should support dual-graph architecture."""
+    rule = SecretRule(enable_dual_graph=True)
+    assert rule.enable_dual_graph is True
+
+    rule_no_dual = SecretRule(enable_dual_graph=False)
+    assert rule_no_dual.enable_dual_graph is False


### PR DESCRIPTION
## Summary

- **Fixed critical bug**: SecretRule used non-existent `db_ops.create_node()` and `db_ops.create_relationship()` methods
- **Corrected API usage**: Now uses `db_ops.upsert_generic()` and `self.create_dual_graph_generic_rel()` as per the standard pattern
- **Registered rule**: SecretRule is now properly registered in `create_relationship_rules()` so it gets applied during scans
- **Added comprehensive tests**: 7 new tests covering all SecretRule functionality

## Root Cause

The original SecretRule implementation called methods that don't exist in the DatabaseOperations class:

```python
# BROKEN - These methods don't exist!
db_ops.create_node("KeyVaultSecret", {...})
db_ops.create_relationship(...)
```

This caused `AttributeError` whenever the rule was invoked, meaning KeyVault secrets were never properly stored in the graph.

## Solution

Follow the same pattern used by other rules (TagRule, RegionRule, etc.):

```python
# FIXED - Uses correct API
db_ops.upsert_generic("KeyVaultSecret", "name", secret_name, {...})
self.create_dual_graph_generic_rel(db_ops, keyvault_id, "STORES_SECRET", ...)
```

## Test Plan

- [x] All 7 new SecretRule tests pass locally
- [x] Verified rule is registered in `create_relationship_rules()`
- [x] Verified rule correctly applies to KeyVault resources with secrets
- [x] Verified KeyVaultSecret nodes are created via `upsert_generic()`
- [x] Verified STORES_SECRET relationships are created
- [x] Pre-commit hooks pass (ruff, ruff format)

## Files Changed

| File | Change |
|------|--------|
| `src/relationship_rules/secret_rule.py` | Fixed API calls, added docstrings |
| `src/relationship_rules/__init__.py` | Import and register SecretRule |
| `tests/test_secret_rule.py` | New test file with 7 comprehensive tests |

Fixes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)