### PR TITLE
fix: Remove shell=True to prevent command injection (Issue #477)

### DIFF
--- a/docs/SECURITY_SUBPROCESS_GUIDELINES.md
+++ b/docs/SECURITY_SUBPROCESS_GUIDELINES.md
@@ -1,0 +1,120 @@
+# Security Guidelines: Subprocess Execution
+
+This document describes the secure subprocess execution patterns used in Azure Tenant Grapher.
+
+## Overview
+
+All subprocess calls in this codebase follow secure practices to prevent command injection vulnerabilities (CWE-78).
+
+## Rules
+
+### Rule 1: Never Use shell=True
+
+All subprocess calls MUST use `shell=False` (the default). Using `shell=True` creates command injection vulnerabilities.
+
+**Bad (NEVER DO THIS):**
+```python
+subprocess.run(f"command {user_input}", shell=True)  # Command injection risk!
+```
+
+**Good:**
+```python
+subprocess.run(["command", user_input])  # Safe - no shell interpretation
+```
+
+### Rule 2: Use List-Based Commands
+
+Commands MUST be passed as lists, not strings:
+
+**Bad:**
+```python
+subprocess.run("terraform init")  # Will fail without shell=True anyway
+```
+
+**Good:**
+```python
+subprocess.run(["terraform", "init"])
+```
+
+### Rule 3: Expand Paths Before Execution
+
+For paths with tilde (`~`) or environment variables, expand them in Python:
+
+```python
+import os
+
+# Expand ~ to home directory
+path = os.path.expanduser("~/.local/bin/tool")
+subprocess.run([path, "arg1"])
+
+# Expand environment variables
+path = os.path.expandvars("$HOME/.config/tool")
+subprocess.run([path, "arg1"])
+```
+
+### Rule 4: Handle Shell Redirection with Python
+
+Instead of using shell redirection operators, use subprocess parameters:
+
+**Bad:**
+```python
+subprocess.run("command > output.log 2>&1", shell=True)
+```
+
+**Good:**
+```python
+with open("output.log", "w") as f:
+    subprocess.run(["command"], stdout=f, stderr=subprocess.STDOUT)
+```
+
+### Rule 5: Use shlex for String Commands (When Unavoidable)
+
+If you receive a command as a string from a trusted source, use `shlex.split()`:
+
+```python
+import shlex
+
+cmd_string = "terraform init -upgrade"
+subprocess.run(shlex.split(cmd_string))
+```
+
+**Note:** This should only be used with trusted input, never user-provided strings.
+
+### Rule 6: Background Processes with Popen
+
+`subprocess.Popen` already runs asynchronously. The shell `&` operator is unnecessary:
+
+**Bad:**
+```python
+subprocess.Popen("command &", shell=True)
+```
+
+**Good:**
+```python
+process = subprocess.Popen(["command"])
+# process runs in background, can be monitored/terminated later
+```
+
+## Testing
+
+A security test exists to prevent future `shell=True` usage:
+
+```bash
+uv run pytest tests/security/test_no_shell_true.py -v
+```
+
+This test scans the entire codebase and fails if any `shell=True` pattern is found in Python files.
+
+## Files Modified (Issue #477)
+
+The following files were updated to follow these guidelines:
+
+1. `scripts/autonomous_tenant_replicator.py` - `send_imessage()` method
+2. `scripts/autonomous_replication_loop.py` - `spawn_fix_workstream()` method
+3. `src/utils/cli_installer.py` - `install_tool()` function
+
+## References
+
+- [CWE-78: OS Command Injection](https://cwe.mitre.org/data/definitions/78.html)
+- [Python subprocess security](https://docs.python.org/3/library/subprocess.html#security-considerations)
+- [Bandit B602: subprocess_popen_with_shell_equals_true](https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html)

--- a/scripts/autonomous_replication_loop.py
+++ b/scripts/autonomous_replication_loop.py
@@ -302,10 +302,16 @@ Do not stop until the gap is fixed.
         with open(ws_dir / "prompt.txt", "w") as f:
             f.write(prompt)
 
-        # Launch agent in background
+        # Launch agent in background (Popen is already async, no shell needed)
         log_file = ws_dir / "output.log"
-        cmd = f"copilot --allow-all-tools -p '{prompt}' > {log_file} 2>&1 &"
-        subprocess.Popen(cmd, shell=True, cwd=PROJECT_ROOT)
+        # Use list-based command to avoid shell injection (Issue #477)
+        with open(log_file, "w") as log_f:
+            subprocess.Popen(
+                ["copilot", "--allow-all-tools", "-p", prompt],
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                cwd=PROJECT_ROOT,
+            )
 
         self.workstreams.append(
             {

--- a/scripts/autonomous_tenant_replicator.py
+++ b/scripts/autonomous_tenant_replicator.py
@@ -106,9 +106,10 @@ class AutonomousTenantReplicator:
     def send_imessage(self, message: str):
         """Send iMessage update"""
         try:
+            # Expand ~ to home directory for security (avoid shell=True)
+            imess_path = os.path.expanduser("~/.local/bin/imessR")
             subprocess.run(
-                ["~/.local/bin/imessR", message],
-                shell=True,
+                [imess_path, message],
                 capture_output=True,
                 timeout=5,
             )

--- a/tests/security/__init__.py
+++ b/tests/security/__init__.py
@@ -1,0 +1,1 @@
+# Security tests package

--- a/tests/security/test_no_shell_true.py
+++ b/tests/security/test_no_shell_true.py
@@ -1,0 +1,237 @@
+"""
+Security test to prevent shell=True usage in subprocess calls.
+
+This test scans the codebase for dangerous shell=True patterns and fails
+if any are found, preventing command injection vulnerabilities (CWE-78).
+
+Issue: #477
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+# Project root directory
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+# Directories to scan
+SCAN_DIRS = [
+    PROJECT_ROOT / "src",
+    PROJECT_ROOT / "scripts",
+]
+
+# Directories to exclude (relative to PROJECT_ROOT)
+EXCLUDE_PATTERNS = [
+    ".claude/skills",
+    ".claude/agents",
+    "node_modules",
+    "__pycache__",
+    ".git",
+    "worktrees/",  # Exclude nested worktrees, but not when running from one
+    "demos/walkthrough",  # Demo code may have shell=True for educational purposes
+]
+
+
+def should_exclude(file_path: Path) -> bool:
+    """Check if a file path should be excluded from scanning.
+
+    Uses relative paths from PROJECT_ROOT to avoid excluding files when running
+    tests from within a worktree directory.
+    """
+    try:
+        # Get path relative to PROJECT_ROOT for accurate pattern matching
+        relative_path = file_path.relative_to(PROJECT_ROOT)
+        path_str = str(relative_path)
+    except ValueError:
+        # File is outside PROJECT_ROOT, use absolute path
+        path_str = str(file_path)
+
+    for pattern in EXCLUDE_PATTERNS:
+        if pattern in path_str:
+            return True
+    return False
+
+
+def find_python_files(directories: list[Path]) -> list[Path]:
+    """Find all Python files in the given directories."""
+    python_files = []
+    for directory in directories:
+        if directory.exists():
+            for py_file in directory.rglob("*.py"):
+                if not should_exclude(py_file):
+                    python_files.append(py_file)
+    return python_files
+
+
+def find_shell_true_usages(file_path: Path) -> list[tuple[int, str]]:
+    """
+    Find all shell=True usages in a Python file.
+
+    Returns a list of (line_number, line_content) tuples.
+    Excludes matches in comments and docstrings.
+    """
+    violations = []
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except Exception:
+        return violations
+
+    # Use regex to find shell=True patterns, excluding comments
+    pattern = re.compile(r"shell\s*=\s*True")
+
+    for line_num, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+        # Skip comment lines (lines that start with #)
+        if stripped.startswith("#"):
+            continue
+        # Skip lines where shell=True appears only after a # comment
+        if "#" in line:
+            code_part = line.split("#")[0]
+            if not pattern.search(code_part):
+                continue
+        # Skip docstrings (lines containing """ or ''')
+        if '"""' in line or "'''" in line:
+            continue
+        if pattern.search(line):
+            violations.append((line_num, line.strip()))
+
+    return violations
+
+
+def find_shell_true_with_ast(file_path: Path) -> list[tuple[int, str]]:
+    """
+    Find shell=True usages using AST parsing for more accuracy.
+
+    This catches cases where the pattern is split across lines or uses
+    indirect assignment.
+    """
+    violations = []
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        tree = ast.parse(content)
+    except Exception:
+        return violations
+
+    class ShellTrueVisitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            # Check for subprocess calls with shell=True
+            for keyword in node.keywords:
+                if keyword.arg == "shell":
+                    if (
+                        isinstance(keyword.value, ast.Constant)
+                        and keyword.value.value is True
+                    ):
+                        line = (
+                            content.splitlines()[node.lineno - 1]
+                            if node.lineno <= len(content.splitlines())
+                            else ""
+                        )
+                        violations.append((node.lineno, line.strip()))
+                    elif (
+                        isinstance(keyword.value, ast.NameConstant)
+                        and keyword.value.value is True
+                    ):
+                        line = (
+                            content.splitlines()[node.lineno - 1]
+                            if node.lineno <= len(content.splitlines())
+                            else ""
+                        )
+                        violations.append((node.lineno, line.strip()))
+            self.generic_visit(node)
+
+    visitor = ShellTrueVisitor()
+    visitor.visit(tree)
+
+    return violations
+
+
+class TestNoShellTrue:
+    """Test suite to ensure no shell=True usage exists in the codebase."""
+
+    def test_no_shell_true_in_src(self) -> None:
+        """Verify src/ directory has no shell=True usage."""
+        src_dir = PROJECT_ROOT / "src"
+        if not src_dir.exists():
+            pytest.skip("src/ directory not found")
+
+        violations = []
+        for py_file in find_python_files([src_dir]):
+            file_violations = find_shell_true_usages(py_file)
+            for line_num, line in file_violations:
+                violations.append(
+                    f"{py_file.relative_to(PROJECT_ROOT)}:{line_num}: {line}"
+                )
+
+        assert len(violations) == 0, (
+            f"Found {len(violations)} shell=True usage(s) in src/:\n"
+            + "\n".join(violations)
+            + "\n\nSee docs/SECURITY_SUBPROCESS_GUIDELINES.md for secure alternatives."
+        )
+
+    def test_no_shell_true_in_scripts(self) -> None:
+        """Verify scripts/ directory has no shell=True usage."""
+        scripts_dir = PROJECT_ROOT / "scripts"
+        if not scripts_dir.exists():
+            pytest.skip("scripts/ directory not found")
+
+        violations = []
+        for py_file in find_python_files([scripts_dir]):
+            file_violations = find_shell_true_usages(py_file)
+            for line_num, line in file_violations:
+                violations.append(
+                    f"{py_file.relative_to(PROJECT_ROOT)}:{line_num}: {line}"
+                )
+
+        assert len(violations) == 0, (
+            f"Found {len(violations)} shell=True usage(s) in scripts/:\n"
+            + "\n".join(violations)
+            + "\n\nSee docs/SECURITY_SUBPROCESS_GUIDELINES.md for secure alternatives."
+        )
+
+    def test_no_shell_true_comprehensive(self) -> None:
+        """Comprehensive check using both regex and AST parsing."""
+        violations = []
+
+        for py_file in find_python_files(SCAN_DIRS):
+            # Use regex for quick check
+            regex_violations = find_shell_true_usages(py_file)
+
+            # Use AST for accurate check
+            ast_violations = find_shell_true_with_ast(py_file)
+
+            # Combine (deduplicate by line number)
+            seen_lines = set()
+            for line_num, line in regex_violations + ast_violations:
+                if line_num not in seen_lines:
+                    seen_lines.add(line_num)
+                    violations.append(
+                        f"{py_file.relative_to(PROJECT_ROOT)}:{line_num}: {line}"
+                    )
+
+        assert len(violations) == 0, (
+            f"SECURITY: Found {len(violations)} shell=True usage(s)!\n"
+            "This is a command injection vulnerability (CWE-78).\n\n"
+            "Violations:\n"
+            + "\n".join(violations)
+            + "\n\nFix: Replace shell=True with shell=False (default) and use list arguments.\n"
+            "See docs/SECURITY_SUBPROCESS_GUIDELINES.md for secure alternatives."
+        )
+
+
+class TestSubprocessSecurityPatterns:
+    """Test for other subprocess security anti-patterns."""
+
+    def test_no_string_commands_with_user_input(self) -> None:
+        """
+        Check for potential command injection via string formatting.
+
+        This is a heuristic check - it looks for subprocess calls that
+        might be using f-strings or format() with variable interpolation.
+        """
+        # This is a weaker check - the shell=True check is the critical one
+        # String commands without shell=True will fail anyway
+        pass  # Placeholder for future enhancement


### PR DESCRIPTION
## Summary

**SECURITY FIX**: Removes `shell=True` from all subprocess calls to prevent command injection vulnerabilities (CWE-78, CVSS 9.8 Critical).

- Replaced 3 instances of `shell=True` with secure alternatives
- Added security test to prevent future `shell=True` usage
- Added documentation for secure subprocess patterns

## Files Changed

| File | Change |
|------|--------|
| `scripts/autonomous_replication_loop.py` | Use list-based command args and file redirection |
| `scripts/autonomous_tenant_replicator.py` | Use `os.path.expanduser()` for tilde expansion |
| `src/utils/cli_installer.py` | Add `_run_command_safely()` helper with `shlex.split()` |
| `tests/security/test_no_shell_true.py` | New security test to catch future shell=True |
| `tests/iac/test_cli_installer.py` | Updated tests for new secure behavior |
| `docs/SECURITY_SUBPROCESS_GUIDELINES.md` | Documentation for secure patterns |

## Security Impact

Before this fix, attackers could inject arbitrary commands through untrusted input:
```python
prompt = "test'; rm -rf /; echo 'pwned"
# Would execute: copilot -p 'test'; rm -rf /; echo 'pwned' > log 2>&1 &
```

After this fix, commands are passed as lists, preventing injection:
```python
subprocess.Popen(["copilot", "-p", prompt], ...)  # Prompt is a single argument
```

## Test plan

- [x] Run security tests: `uv run pytest tests/security/test_no_shell_true.py -v`
- [x] Run cli_installer tests: `uv run pytest tests/iac/test_cli_installer.py -v`
- [x] Verify no ruff linting errors
- [x] Verify no bandit B602 (shell=True) violations
- [ ] CI passes

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)