### PR TITLE
refactor: Decompose terraform_emitter.py into handler-based architecture (Issue #476)

### DIFF
--- a/src/iac/emitters/terraform/__init__.py
+++ b/src/iac/emitters/terraform/__init__.py
@@ -1,0 +1,37 @@
+"""Terraform emitter package for Azure resource IaC generation.
+
+This package provides handler-based Terraform configuration generation
+from Azure resources. The architecture follows a Strategy pattern where
+individual handlers are responsible for specific Azure resource types.
+
+Main Components:
+- TerraformEmitter: Main orchestrator for emission process
+- EmitterContext: Shared state passed to all handlers
+- ResourceHandler: Abstract base class for handlers
+- HandlerRegistry: Registry for handler lookup by Azure type
+
+Usage:
+    from src.iac.emitters.terraform import TerraformEmitter
+
+    emitter = TerraformEmitter(
+        target_subscription_id="xxx-xxx-xxx",
+        target_tenant_id="yyy-yyy-yyy",
+    )
+    config = emitter.emit(resources)
+    emitter.write(config, Path("/output"))
+"""
+
+from .context import EmitterContext
+from .emitter import TerraformEmitter
+from .handlers import HandlerRegistry, ensure_handlers_registered, handler
+
+__all__ = [
+    "EmitterContext",
+    "HandlerRegistry",
+    "TerraformEmitter",
+    "ensure_handlers_registered",
+    "handler",
+]
+
+# Version for tracking compatibility
+__version__ = "2.0.0"  # Handler-based architecture

--- a/src/iac/emitters/terraform/base_handler.py
+++ b/src/iac/emitters/terraform/base_handler.py
@@ -1,0 +1,338 @@
+"""Base handler interface for Azure resource type handlers.
+
+This module defines the abstract base class that all resource handlers
+must implement. Each handler is responsible for converting one or more
+Azure resource types into Terraform resource configurations.
+"""
+
+import json
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from .context import EmitterContext
+
+logger = logging.getLogger(__name__)
+
+
+class ResourceHandler(ABC):
+    """Abstract base class for Azure resource type handlers.
+
+    Each handler is responsible for converting one or more Azure resource
+    types into Terraform resource configurations.
+
+    Handlers should be:
+    - Focused: Handle related resource types only
+    - Stateless: Use EmitterContext for shared state
+    - Testable: Pure functions where possible
+    - Self-documenting: Clear mapping declarations
+
+    Usage:
+        @handler
+        class StorageAccountHandler(ResourceHandler):
+            HANDLED_TYPES = {"Microsoft.Storage/storageAccounts"}
+            TERRAFORM_TYPES = {"azurerm_storage_account"}
+
+            def emit(self, resource, context):
+                # Convert resource to Terraform config
+                return ("azurerm_storage_account", "name", {...})
+    """
+
+    # Class-level declaration of handled Azure types
+    # Subclasses MUST override this
+    HANDLED_TYPES: ClassVar[Set[str]] = set()
+
+    # Terraform resource type(s) this handler emits
+    # Used for documentation and testing
+    TERRAFORM_TYPES: ClassVar[Set[str]] = set()
+
+    @classmethod
+    def can_handle(cls, azure_type: str) -> bool:
+        """Check if this handler can process the given Azure type.
+
+        Args:
+            azure_type: Azure resource type (e.g., "Microsoft.Compute/virtualMachines")
+
+        Returns:
+            True if handler can process this type
+        """
+        azure_type_lower = azure_type.lower()
+        return any(t.lower() == azure_type_lower for t in cls.HANDLED_TYPES)
+
+    @abstractmethod
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure resource to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+
+        Note:
+            - Return None to skip the resource (with logging)
+            - May add helper resources to context.terraform_config
+            - Should validate references before emitting
+        """
+        raise NotImplementedError
+
+    def post_emit(self, context: EmitterContext) -> None:  # noqa: B027
+        """Called after all resources are emitted.
+
+        Override to emit deferred resources like associations.
+        Default implementation does nothing (intentional - not abstract).
+
+        Args:
+            context: Shared emitter context
+        """
+
+    # Utility methods available to all handlers
+
+    @staticmethod
+    def parse_properties(resource: Dict[str, Any]) -> Dict[str, Any]:
+        """Parse JSON properties from resource.
+
+        Args:
+            resource: Azure resource dict with properties field
+
+        Returns:
+            Parsed properties dict (empty dict if parsing fails)
+        """
+        properties = resource.get("properties", "{}")
+        if isinstance(properties, str):
+            try:
+                return json.loads(properties)
+            except json.JSONDecodeError:
+                logger.warning(
+                    f"Failed to parse properties for resource '{resource.get('name')}'"
+                )
+                return {}
+        return properties if isinstance(properties, dict) else {}
+
+    @staticmethod
+    def sanitize_name(name: str) -> str:
+        """Sanitize resource name for Terraform compatibility.
+
+        Args:
+            name: Original resource name
+
+        Returns:
+            Sanitized name safe for Terraform
+        """
+        # Replace invalid characters with underscores
+        sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+        # Ensure it starts with a letter or underscore
+        if sanitized and sanitized[0].isdigit():
+            sanitized = f"resource_{sanitized}"
+
+        return sanitized or "unnamed_resource"
+
+    @staticmethod
+    def extract_name_from_id(resource_id: str, resource_type: str) -> str:
+        """Extract resource name from Azure resource ID.
+
+        Args:
+            resource_id: Full Azure resource ID
+            resource_type: Azure resource type segment (e.g., "subnets", "virtualNetworks")
+
+        Returns:
+            Extracted resource name or "unknown"
+        """
+        if not resource_id:
+            return "unknown"
+
+        path_segment = f"/{resource_type}/"
+        if path_segment in resource_id:
+            return resource_id.split(path_segment)[-1].split("/")[0]
+        return "unknown"
+
+    @staticmethod
+    def parse_tags(tags: Any, resource_name: str) -> Optional[Dict[str, str]]:
+        """Parse tags from resource.
+
+        Args:
+            tags: Tags field (string, dict, or None)
+            resource_name: Resource name for logging
+
+        Returns:
+            Parsed tags dict or None
+        """
+        if tags is None:
+            return None
+
+        if isinstance(tags, dict):
+            # Validate all values are strings
+            if all(isinstance(v, str) for v in tags.values()):
+                return tags if tags else None
+            # Try to convert non-string values
+            return {k: str(v) for k, v in tags.items()} if tags else None
+
+        if isinstance(tags, str):
+            try:
+                parsed = json.loads(tags)
+                if isinstance(parsed, dict) and parsed:
+                    return {k: str(v) for k, v in parsed.items()}
+            except json.JSONDecodeError:
+                logger.warning(
+                    f"Failed to parse tags JSON for resource '{resource_name}'"
+                )
+
+        return None
+
+    @staticmethod
+    def get_location(resource: Dict[str, Any], default: str = "eastus") -> str:
+        """Get normalized location from resource.
+
+        Args:
+            resource: Azure resource dict
+            default: Default location if not found or invalid
+
+        Returns:
+            Valid location string
+        """
+        location = resource.get("location")
+        if not location or location.lower() in ["none", "null", "global"]:
+            if location and location.lower() == "global":
+                logger.warning(
+                    f"Resource '{resource.get('name')}' has invalid location 'global', "
+                    f"using '{default}' fallback"
+                )
+            return default
+        return location
+
+    @staticmethod
+    def get_resource_group(resource: Dict[str, Any]) -> Optional[str]:
+        """Get resource group name from resource.
+
+        Args:
+            resource: Azure resource dict
+
+        Returns:
+            Resource group name or None
+        """
+        return resource.get("resource_group") or resource.get("resourceGroup")
+
+    def validate_resource_reference(
+        self,
+        terraform_type: str,
+        name: str,
+        context: EmitterContext,
+    ) -> bool:
+        """Validate that a referenced resource exists.
+
+        Args:
+            terraform_type: Terraform resource type
+            name: Terraform resource name (sanitized)
+            context: Emitter context with resource tracking
+
+        Returns:
+            True if resource exists in context or terraform config
+        """
+        # Check context tracking
+        if context.resource_exists(terraform_type, name):
+            return True
+
+        # Check terraform config directly
+        config_resources = context.terraform_config.get("resource", {})
+        if terraform_type in config_resources:
+            if name in config_resources[terraform_type]:
+                return True
+
+        return False
+
+    def build_base_config(
+        self,
+        resource: Dict[str, Any],
+        resource_name_with_suffix: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build base resource configuration with common fields.
+
+        Args:
+            resource: Azure resource dict
+            resource_name_with_suffix: Optional name with unique suffix applied
+
+        Returns:
+            Base config with name, location, resource_group_name
+        """
+        name = resource_name_with_suffix or resource.get("name", "unknown")
+        location = self.get_location(resource)
+        rg_name = self.get_resource_group(resource)
+
+        config = {
+            "name": name,
+            "location": location,
+            "resource_group_name": rg_name,
+        }
+
+        # Add tags if present
+        tags = resource.get("tags")
+        if tags:
+            parsed_tags = self.parse_tags(tags, resource.get("name", "unknown"))
+            if parsed_tags:
+                config["tags"] = parsed_tags
+
+        return config
+
+    @staticmethod
+    def normalize_cidr_block(cidr: str, context_name: str) -> Optional[str]:
+        """Normalize a CIDR block to standard format.
+
+        Args:
+            cidr: CIDR block string
+            context_name: Resource name for logging context
+
+        Returns:
+            Normalized CIDR or None if invalid
+        """
+        if not cidr or not isinstance(cidr, str):
+            return None
+
+        cidr = cidr.strip()
+
+        # Basic validation
+        if "/" not in cidr:
+            logger.warning(f"CIDR '{cidr}' for '{context_name}' missing prefix length")
+            return None
+
+        try:
+            ip_part, prefix_part = cidr.split("/")
+            prefix = int(prefix_part)
+
+            # Validate prefix length
+            if prefix < 0 or prefix > 32:
+                logger.warning(
+                    f"CIDR '{cidr}' for '{context_name}' has invalid prefix: {prefix}"
+                )
+                return None
+
+            # Validate IP parts
+            parts = ip_part.split(".")
+            if len(parts) != 4:
+                logger.warning(
+                    f"CIDR '{cidr}' for '{context_name}' has invalid IP format"
+                )
+                return None
+
+            # Validate each octet
+            for part in parts:
+                octet = int(part)
+                if octet < 0 or octet > 255:
+                    logger.warning(
+                        f"CIDR '{cidr}' for '{context_name}' has invalid octet: {octet}"
+                    )
+                    return None
+
+            return cidr
+
+        except (ValueError, AttributeError) as e:
+            logger.warning(
+                f"Failed to normalize CIDR '{cidr}' for '{context_name}': {e}"
+            )
+            return None

--- a/src/iac/emitters/terraform/context.py
+++ b/src/iac/emitters/terraform/context.py
@@ -1,0 +1,185 @@
+"""EmitterContext - Shared state passed to all handlers during emission.
+
+This module contains the EmitterContext dataclass that encapsulates all
+shared state and configuration needed by resource handlers during
+Terraform template generation.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+
+@dataclass
+class EmitterContext:
+    """Shared context passed to all handlers during emission.
+
+    This dataclass encapsulates all shared state that handlers need:
+    - Target configuration (subscription, tenant IDs)
+    - Terraform config being built
+    - Resource tracking for reference validation
+    - Association tracking for deferred resource emission
+    - Error tracking for missing references
+
+    Usage:
+        context = EmitterContext(
+            target_subscription_id="xxx",
+            target_tenant_id="yyy",
+        )
+        handler.emit(resource, context)
+    """
+
+    # Target configuration
+    target_subscription_id: Optional[str] = None
+    target_tenant_id: Optional[str] = None
+    source_subscription_id: Optional[str] = None
+    source_tenant_id: Optional[str] = None
+    identity_mapping: Optional[Dict[str, Any]] = None
+    resource_group_prefix: str = ""
+    strict_mode: bool = False
+
+    # Terraform config being built
+    terraform_config: Dict[str, Any] = field(default_factory=dict)
+
+    # Resource tracking for reference validation
+    available_resources: Dict[str, Set[str]] = field(default_factory=dict)
+    available_subnets: Set[str] = field(default_factory=set)
+    available_resource_groups: Set[str] = field(default_factory=set)
+
+    # VNet ID mapping for subnet references (Bug #31)
+    vnet_id_to_terraform_name: Dict[str, str] = field(default_factory=dict)
+
+    # Association tracking (emitted after main resources)
+    nsg_associations: List[tuple] = field(default_factory=list)
+    nic_nsg_associations: List[tuple] = field(default_factory=list)
+
+    # Error tracking
+    missing_references: List[Dict[str, str]] = field(default_factory=list)
+
+    # Graph reference for validation
+    graph: Optional[Any] = None
+
+    # Translation coordinator
+    translation_coordinator: Optional[Any] = None
+
+    def add_resource(self, terraform_type: str, name: str) -> None:
+        """Track a resource that will be emitted.
+
+        Args:
+            terraform_type: Terraform resource type (e.g., "azurerm_virtual_network")
+            name: Terraform resource name (sanitized)
+        """
+        if terraform_type not in self.available_resources:
+            self.available_resources[terraform_type] = set()
+        self.available_resources[terraform_type].add(name)
+
+    def resource_exists(self, terraform_type: str, name: str) -> bool:
+        """Check if a resource exists in tracking.
+
+        Args:
+            terraform_type: Terraform resource type
+            name: Terraform resource name (sanitized)
+
+        Returns:
+            True if resource is being tracked
+        """
+        return name in self.available_resources.get(terraform_type, set())
+
+    def add_helper_resource(
+        self,
+        resource_type: str,
+        name: str,
+        config: Dict[str, Any],
+    ) -> None:
+        """Add a helper resource to terraform config.
+
+        Helper resources are additional resources generated alongside
+        the main resource (e.g., SSH keys for VMs, passwords for SQL servers).
+
+        Args:
+            resource_type: Terraform resource type (e.g., "tls_private_key")
+            name: Resource name
+            config: Resource configuration dict
+        """
+        if "resource" not in self.terraform_config:
+            self.terraform_config["resource"] = {}
+        if resource_type not in self.terraform_config["resource"]:
+            self.terraform_config["resource"][resource_type] = {}
+        self.terraform_config["resource"][resource_type][name] = config
+
+    def get_effective_subscription_id(self, resource: Dict[str, Any]) -> str:
+        """Get the subscription ID to use for resource construction.
+
+        In cross-tenant mode, returns target subscription ID.
+        Otherwise returns the resource's original subscription ID.
+
+        Args:
+            resource: Resource dictionary with subscription_id field
+
+        Returns:
+            Subscription ID to use in constructed resource IDs
+        """
+        if self.target_subscription_id:
+            return self.target_subscription_id
+        return resource.get("subscription_id", "")
+
+    def track_nsg_association(
+        self,
+        subnet_tf_name: str,
+        nsg_tf_name: str,
+        subnet_name: str,
+        nsg_name: str,
+    ) -> None:
+        """Track an NSG-subnet association for deferred emission.
+
+        Args:
+            subnet_tf_name: Terraform name for subnet
+            nsg_tf_name: Terraform name for NSG
+            subnet_name: Original Azure subnet name
+            nsg_name: Original Azure NSG name
+        """
+        self.nsg_associations.append(
+            (subnet_tf_name, nsg_tf_name, subnet_name, nsg_name)
+        )
+
+    def track_nic_nsg_association(
+        self,
+        nic_tf_name: str,
+        nsg_tf_name: str,
+        nic_name: str,
+        nsg_name: str,
+    ) -> None:
+        """Track a NIC-NSG association for deferred emission.
+
+        Args:
+            nic_tf_name: Terraform name for NIC
+            nsg_tf_name: Terraform name for NSG
+            nic_name: Original Azure NIC name
+            nsg_name: Original Azure NSG name
+        """
+        self.nic_nsg_associations.append((nic_tf_name, nsg_tf_name, nic_name, nsg_name))
+
+    def track_missing_reference(
+        self,
+        resource_name: str,
+        resource_type: str,
+        missing_resource_name: str,
+        missing_resource_id: str,
+        **extra: Any,
+    ) -> None:
+        """Track a missing resource reference for reporting.
+
+        Args:
+            resource_name: Name of resource with missing reference
+            resource_type: Type of missing resource
+            missing_resource_name: Name of missing resource
+            missing_resource_id: Azure ID of missing resource
+            **extra: Additional context fields
+        """
+        ref_info = {
+            "resource_name": resource_name,
+            "resource_type": resource_type,
+            "missing_resource_name": missing_resource_name,
+            "missing_resource_id": missing_resource_id,
+        }
+        ref_info.update(extra)
+        self.missing_references.append(ref_info)

--- a/src/iac/emitters/terraform/emitter.py
+++ b/src/iac/emitters/terraform/emitter.py
@@ -1,0 +1,435 @@
+"""TerraformEmitter - Main orchestrator for handler-based Terraform generation.
+
+This module provides the main TerraformEmitter class that orchestrates
+resource-to-Terraform conversion using registered handlers. It replaces
+the monolithic _convert_resource() method with handler delegation.
+
+Architecture:
+    Emitter (this file) -> HandlerRegistry -> Individual Handlers
+                       |
+                       v
+                  EmitterContext (shared state)
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .context import EmitterContext
+from .handlers import HandlerRegistry, ensure_handlers_registered
+
+logger = logging.getLogger(__name__)
+
+
+class TerraformEmitter:
+    """Main orchestrator for Terraform IaC generation.
+
+    Delegates resource conversion to registered handlers while managing
+    overall configuration structure and output.
+
+    Responsibilities:
+    - Initialize context with target configuration
+    - Iterate resources and dispatch to handlers
+    - Collect and structure handler output
+    - Emit deferred resources (NSG associations, etc.)
+    - Generate final Terraform configuration
+
+    Usage:
+        emitter = TerraformEmitter(
+            target_subscription_id="xxx",
+            target_tenant_id="yyy",
+        )
+        config = emitter.emit(resources)
+        emitter.write(config, output_dir)
+    """
+
+    def __init__(
+        self,
+        target_subscription_id: Optional[str] = None,
+        target_tenant_id: Optional[str] = None,
+        source_subscription_id: Optional[str] = None,
+        source_tenant_id: Optional[str] = None,
+        identity_mapping: Optional[Dict[str, Any]] = None,
+        resource_group_prefix: str = "",
+        strict_mode: bool = False,
+        graph: Optional[Any] = None,
+        translation_coordinator: Optional[Any] = None,
+    ):
+        """Initialize emitter with target configuration.
+
+        Args:
+            target_subscription_id: Target Azure subscription ID for cross-tenant
+            target_tenant_id: Target Azure tenant ID for cross-tenant
+            source_subscription_id: Source subscription ID from scan
+            source_tenant_id: Source tenant ID from scan
+            identity_mapping: Entra ID identity translation mapping
+            resource_group_prefix: Prefix to add to resource group names
+            strict_mode: If True, fail on validation errors
+            graph: Neo4j graph client for reference lookups
+            translation_coordinator: Cross-tenant translation coordinator
+        """
+        self.context = EmitterContext(
+            target_subscription_id=target_subscription_id,
+            target_tenant_id=target_tenant_id,
+            source_subscription_id=source_subscription_id,
+            source_tenant_id=source_tenant_id,
+            identity_mapping=identity_mapping or {},
+            resource_group_prefix=resource_group_prefix,
+            strict_mode=strict_mode,
+            graph=graph,
+            translation_coordinator=translation_coordinator,
+        )
+
+        # Ensure handlers are registered
+        ensure_handlers_registered()
+
+        # Track statistics
+        self.stats = {
+            "total_resources": 0,
+            "emitted_resources": 0,
+            "skipped_resources": 0,
+            "unsupported_types": set(),
+            "handler_errors": [],
+        }
+
+    def emit(self, resources: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Convert list of Azure resources to Terraform configuration.
+
+        Args:
+            resources: List of Azure resource dictionaries from graph
+
+        Returns:
+            Complete Terraform configuration dict
+        """
+        logger.info(f"Starting Terraform emission for {len(resources)} resources")
+        self.stats["total_resources"] = len(resources)
+
+        # Initialize terraform config structure
+        self.context.terraform_config = {
+            "terraform": {
+                "required_version": ">= 1.5.0",
+                "required_providers": {
+                    "azurerm": {
+                        "source": "hashicorp/azurerm",
+                        "version": "~> 3.80",
+                    },
+                    "azuread": {
+                        "source": "hashicorp/azuread",
+                        "version": "~> 2.45",
+                    },
+                    "random": {
+                        "source": "hashicorp/random",
+                        "version": "~> 3.5",
+                    },
+                    "tls": {
+                        "source": "hashicorp/tls",
+                        "version": "~> 4.0",
+                    },
+                },
+            },
+            "provider": {
+                "azurerm": {"features": {}},
+                "azuread": {},
+            },
+            "resource": {},
+            "variable": {},
+            "output": {},
+        }
+
+        # Phase 1: Emit main resources
+        self._emit_resources(resources)
+
+        # Phase 2: Emit deferred resources (NSG associations, etc.)
+        self._emit_deferred_resources()
+
+        # Phase 3: Call post_emit on all handlers
+        self._post_emit_handlers()
+
+        # Log statistics
+        self._log_statistics()
+
+        return self.context.terraform_config
+
+    def _emit_resources(self, resources: List[Dict[str, Any]]) -> None:
+        """Emit all resources using registered handlers.
+
+        Args:
+            resources: List of Azure resource dictionaries
+        """
+        for resource in resources:
+            azure_type = resource.get("type", "unknown")
+
+            # Get handler for this resource type
+            handler = HandlerRegistry.get_handler(azure_type)
+
+            if handler is None:
+                self.stats["unsupported_types"].add(azure_type)
+                self.stats["skipped_resources"] += 1
+                logger.debug(f"No handler for type: {azure_type}")
+                continue
+
+            try:
+                # Emit the resource
+                result = handler.emit(resource, self.context)
+
+                if result is None:
+                    self.stats["skipped_resources"] += 1
+                    logger.debug(
+                        f"Handler skipped resource: {resource.get('name')} "
+                        f"({azure_type})"
+                    )
+                    continue
+
+                # Unpack result
+                terraform_type, terraform_name, config = result
+
+                # Add to terraform config
+                self._add_resource(terraform_type, terraform_name, config)
+                self.stats["emitted_resources"] += 1
+
+            except Exception as e:
+                self.stats["handler_errors"].append(
+                    {
+                        "resource": resource.get("name", "unknown"),
+                        "type": azure_type,
+                        "error": str(e),
+                    }
+                )
+                logger.warning(
+                    f"Handler error for {resource.get('name')} ({azure_type}): {e}"
+                )
+                if self.context.strict_mode:
+                    raise
+
+    def _add_resource(
+        self,
+        terraform_type: str,
+        terraform_name: str,
+        config: Dict[str, Any],
+    ) -> None:
+        """Add a resource to terraform configuration.
+
+        Args:
+            terraform_type: Terraform resource type
+            terraform_name: Terraform resource name
+            config: Resource configuration dict
+        """
+        resources = self.context.terraform_config.setdefault("resource", {})
+        type_resources = resources.setdefault(terraform_type, {})
+        type_resources[terraform_name] = config
+
+        # Track in context for reference validation
+        self.context.add_resource(terraform_type, terraform_name)
+
+    def _emit_deferred_resources(self) -> None:
+        """Emit deferred resources like NSG associations.
+
+        These are emitted after main resources to ensure all referenced
+        resources exist.
+        """
+        # Emit subnet-NSG associations
+        for subnet_tf, nsg_tf, subnet_name, nsg_name in self.context.nsg_associations:
+            # Validate both resources exist
+            if not self.context.resource_exists("azurerm_subnet", subnet_tf):
+                logger.warning(
+                    f"Skipping NSG association: subnet '{subnet_name}' not emitted"
+                )
+                continue
+            if not self.context.resource_exists(
+                "azurerm_network_security_group", nsg_tf
+            ):
+                logger.warning(
+                    f"Skipping NSG association: NSG '{nsg_name}' not emitted"
+                )
+                continue
+
+            assoc_name = f"{subnet_tf}_to_{nsg_tf}"
+            self._add_resource(
+                "azurerm_subnet_network_security_group_association",
+                assoc_name,
+                {
+                    "subnet_id": f"${{azurerm_subnet.{subnet_tf}.id}}",
+                    "network_security_group_id": (
+                        f"${{azurerm_network_security_group.{nsg_tf}.id}}"
+                    ),
+                },
+            )
+            logger.debug(f"Emitted NSG association: {subnet_name} -> {nsg_name}")
+
+        # Emit NIC-NSG associations (Bug #57)
+        for nic_tf, nsg_tf, nic_name, nsg_name in self.context.nic_nsg_associations:
+            # Validate both resources exist
+            if not self.context.resource_exists("azurerm_network_interface", nic_tf):
+                logger.warning(
+                    f"Skipping NIC-NSG association: NIC '{nic_name}' not emitted"
+                )
+                continue
+            if not self.context.resource_exists(
+                "azurerm_network_security_group", nsg_tf
+            ):
+                logger.warning(
+                    f"Skipping NIC-NSG association: NSG '{nsg_name}' not emitted"
+                )
+                continue
+
+            assoc_name = f"{nic_tf}_to_{nsg_tf}"
+            self._add_resource(
+                "azurerm_network_interface_security_group_association",
+                assoc_name,
+                {
+                    "network_interface_id": f"${{azurerm_network_interface.{nic_tf}.id}}",
+                    "network_security_group_id": (
+                        f"${{azurerm_network_security_group.{nsg_tf}.id}}"
+                    ),
+                },
+            )
+            logger.debug(f"Emitted NIC-NSG association: {nic_name} -> {nsg_name}")
+
+    def _post_emit_handlers(self) -> None:
+        """Call post_emit on all handlers.
+
+        Some handlers need to emit additional resources after all main
+        resources have been processed.
+        """
+        for handler_class in HandlerRegistry.get_all_handlers():
+            try:
+                handler = handler_class()
+                handler.post_emit(self.context)
+            except Exception as e:
+                logger.warning(f"Error in post_emit for {handler_class.__name__}: {e}")
+                if self.context.strict_mode:
+                    raise
+
+    def _log_statistics(self) -> None:
+        """Log emission statistics."""
+        logger.info(
+            f"Terraform emission complete: "
+            f"{self.stats['emitted_resources']}/{self.stats['total_resources']} "
+            f"resources emitted"
+        )
+
+        if self.stats["skipped_resources"] > 0:
+            logger.info(
+                f"Skipped {self.stats['skipped_resources']} resources "
+                f"({len(self.stats['unsupported_types'])} unsupported types)"
+            )
+
+        if self.stats["unsupported_types"]:
+            sorted_types = sorted(self.stats["unsupported_types"])
+            logger.debug(f"Unsupported types: {sorted_types[:10]}...")
+
+        if self.stats["handler_errors"]:
+            logger.warning(
+                f"Handler errors: {len(self.stats['handler_errors'])} "
+                f"resources had errors"
+            )
+
+        if self.context.missing_references:
+            logger.warning(
+                f"Missing references: {len(self.context.missing_references)} "
+                f"references could not be resolved"
+            )
+
+    def write(
+        self,
+        config: Dict[str, Any],
+        output_dir: Path,
+        filename: str = "main.tf.json",
+    ) -> Path:
+        """Write Terraform configuration to file.
+
+        Args:
+            config: Terraform configuration dict
+            output_dir: Output directory path
+            filename: Output filename (default: main.tf.json)
+
+        Returns:
+            Path to written file
+        """
+        import json
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        output_file = output_dir / filename
+
+        with open(output_file, "w") as f:
+            json.dump(config, f, indent=2, sort_keys=False)
+
+        logger.info(f"Terraform configuration written to {output_file}")
+        return output_file
+
+    def get_supported_types(self) -> List[str]:
+        """Get list of supported Azure resource types.
+
+        Returns:
+            Sorted list of supported Azure resource types
+        """
+        return HandlerRegistry.get_all_supported_types()
+
+    def get_statistics(self) -> Dict[str, Any]:
+        """Get emission statistics.
+
+        Returns:
+            Dictionary with emission statistics
+        """
+        return {
+            "total_resources": self.stats["total_resources"],
+            "emitted_resources": self.stats["emitted_resources"],
+            "skipped_resources": self.stats["skipped_resources"],
+            "unsupported_types_count": len(self.stats["unsupported_types"]),
+            "handler_errors_count": len(self.stats["handler_errors"]),
+            "missing_references_count": len(self.context.missing_references),
+        }
+
+    def add_variable(
+        self,
+        name: str,
+        var_type: str = "string",
+        description: str = "",
+        default: Optional[Any] = None,
+        sensitive: bool = False,
+    ) -> None:
+        """Add a variable to terraform configuration.
+
+        Args:
+            name: Variable name
+            var_type: Variable type (string, number, bool, list, map)
+            description: Variable description
+            default: Default value (None = required)
+            sensitive: Whether variable is sensitive
+        """
+        var_config: Dict[str, Any] = {"type": var_type}
+
+        if description:
+            var_config["description"] = description
+        if default is not None:
+            var_config["default"] = default
+        if sensitive:
+            var_config["sensitive"] = True
+
+        self.context.terraform_config.setdefault("variable", {})[name] = var_config
+
+    def add_output(
+        self,
+        name: str,
+        value: str,
+        description: str = "",
+        sensitive: bool = False,
+    ) -> None:
+        """Add an output to terraform configuration.
+
+        Args:
+            name: Output name
+            value: Output value expression
+            description: Output description
+            sensitive: Whether output is sensitive
+        """
+        output_config: Dict[str, Any] = {"value": value}
+
+        if description:
+            output_config["description"] = description
+        if sensitive:
+            output_config["sensitive"] = True
+
+        self.context.terraform_config.setdefault("output", {})[name] = output_config

--- a/src/iac/emitters/terraform/handlers/__init__.py
+++ b/src/iac/emitters/terraform/handlers/__init__.py
@@ -1,0 +1,239 @@
+"""Handler registry for resource type dispatch.
+
+This module provides the HandlerRegistry class that manages registration
+and lookup of resource handlers based on Azure resource types.
+"""
+
+import logging
+from typing import Dict, List, Optional, Type
+
+from ..base_handler import ResourceHandler
+
+logger = logging.getLogger(__name__)
+
+
+class HandlerRegistry:
+    """Registry for resource handlers with type-based dispatch.
+
+    The registry maintains a list of handler classes and provides
+    efficient lookup by Azure resource type.
+
+    Usage:
+        @handler
+        class MyHandler(ResourceHandler):
+            HANDLED_TYPES = {"Microsoft.Storage/storageAccounts"}
+            ...
+
+        # Later:
+        handler = HandlerRegistry.get_handler("Microsoft.Storage/storageAccounts")
+        if handler:
+            result = handler.emit(resource, context)
+    """
+
+    _handlers: List[Type[ResourceHandler]] = []
+    _type_cache: Dict[str, Type[ResourceHandler]] = {}
+
+    @classmethod
+    def register(cls, handler_class: Type[ResourceHandler]) -> Type[ResourceHandler]:
+        """Register a handler class.
+
+        Use as decorator:
+            @HandlerRegistry.register
+            class MyHandler(ResourceHandler):
+                ...
+
+        Args:
+            handler_class: Handler class to register
+
+        Returns:
+            The handler class (unchanged)
+        """
+        # Avoid duplicate registration
+        if handler_class not in cls._handlers:
+            cls._handlers.append(handler_class)
+
+            # Pre-populate cache for fast lookup
+            for azure_type in handler_class.HANDLED_TYPES:
+                cls._type_cache[azure_type.lower()] = handler_class
+                logger.debug(
+                    f"Registered handler {handler_class.__name__} for {azure_type}"
+                )
+
+        return handler_class
+
+    @classmethod
+    def get_handler(cls, azure_type: str) -> Optional[ResourceHandler]:
+        """Get handler instance for Azure type.
+
+        Args:
+            azure_type: Azure resource type (e.g., "Microsoft.Compute/virtualMachines")
+
+        Returns:
+            Handler instance or None if no handler registered
+        """
+        azure_type_lower = azure_type.lower()
+
+        # Fast path: cached lookup
+        if azure_type_lower in cls._type_cache:
+            return cls._type_cache[azure_type_lower]()
+
+        # Slow path: iterate handlers (for flexible matching)
+        for handler_class in cls._handlers:
+            if handler_class.can_handle(azure_type):
+                # Cache for next time
+                cls._type_cache[azure_type_lower] = handler_class
+                return handler_class()
+
+        return None
+
+    @classmethod
+    def get_all_supported_types(cls) -> List[str]:
+        """Get all Azure types supported by registered handlers.
+
+        Returns:
+            Sorted list of supported Azure resource types
+        """
+        types = set()
+        for handler_class in cls._handlers:
+            types.update(handler_class.HANDLED_TYPES)
+        return sorted(types)
+
+    @classmethod
+    def get_all_handlers(cls) -> List[Type[ResourceHandler]]:
+        """Get all registered handler classes.
+
+        Returns:
+            List of handler classes (copy)
+        """
+        return cls._handlers.copy()
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all registered handlers.
+
+        Primarily for testing.
+        """
+        cls._handlers = []
+        cls._type_cache = {}
+
+
+def handler(cls: Type[ResourceHandler]) -> Type[ResourceHandler]:
+    """Decorator to register a handler class.
+
+    Usage:
+        @handler
+        class StorageAccountHandler(ResourceHandler):
+            HANDLED_TYPES = {"Microsoft.Storage/storageAccounts"}
+            ...
+    """
+    return HandlerRegistry.register(cls)
+
+
+# Import all handler modules to trigger registration
+# This must be at the bottom after the registry is defined
+def _register_all_handlers() -> None:
+    """Import all handler modules to trigger registration."""
+    # Storage handlers
+    # Automation handlers
+    from .automation import automation_account, runbook
+
+    # Compute handlers
+    from .compute import (
+        disks,
+        ssh_public_key,
+        virtual_machine,
+        vm_extensions,
+    )
+
+    # Container handlers
+    from .container import (
+        aks,
+        container_app,
+        container_group,
+        container_registry,
+    )
+
+    # Database handlers
+    from .database import cosmosdb, postgresql, sql_database, sql_server
+
+    # DevTest handlers
+    from .devtest import devtest_lab, devtest_schedule, devtest_vm
+
+    # Identity handlers
+    from .identity import (
+        entra_group,
+        entra_user,
+        managed_identity,
+        role_assignment,
+        service_principal,
+    )
+
+    # KeyVault handlers
+    from .keyvault import vault
+
+    # Misc handlers
+    from .misc import (
+        app_config,
+        data_factory,
+        databricks,
+        dns_zone,
+        eventhub,
+        recovery_vault,
+        redis,
+        resource_group,
+        search_service,
+        servicebus,
+        waf_policy,
+    )
+
+    # ML handlers
+    from .ml import cognitive_services, ml_workspace
+
+    # Monitoring handlers
+    from .monitoring import (
+        action_group,
+        app_insights,
+        dcr,
+        log_analytics,
+        metric_alert,
+    )
+
+    # Network handlers
+    from .network import (
+        bastion,
+        nat_gateway,
+        nic,
+        nsg,
+        public_ip,
+        route_table,
+        subnet,
+        vnet,
+    )
+    from .storage import storage_account
+
+    # Web handlers
+    from .web import app_service, service_plan, static_web_app
+
+    logger.info(
+        f"Registered {len(HandlerRegistry._handlers)} handlers "
+        f"covering {len(HandlerRegistry.get_all_supported_types())} Azure types"
+    )
+
+
+# Delay registration until first use to allow handler files to be created
+_handlers_registered = False
+
+
+def ensure_handlers_registered() -> None:
+    """Ensure all handlers are registered.
+
+    Called lazily on first handler lookup.
+    """
+    global _handlers_registered
+    if not _handlers_registered:
+        try:
+            _register_all_handlers()
+        except ImportError as e:
+            # During development, some handlers may not exist yet
+            logger.warning(f"Some handlers not available: {e}")
+        _handlers_registered = True

--- a/src/iac/emitters/terraform/handlers/automation/__init__.py
+++ b/src/iac/emitters/terraform/handlers/automation/__init__.py
@@ -1,0 +1,9 @@
+"""Automation handlers for Terraform emission."""
+
+from .automation_account import AutomationAccountHandler
+from .runbook import AutomationRunbookHandler
+
+__all__ = [
+    "AutomationAccountHandler",
+    "AutomationRunbookHandler",
+]

--- a/src/iac/emitters/terraform/handlers/automation/automation_account.py
+++ b/src/iac/emitters/terraform/handlers/automation/automation_account.py
@@ -1,0 +1,53 @@
+"""Automation Account handler for Terraform emission.
+
+Handles: Microsoft.Automation/automationAccounts
+Emits: azurerm_automation_account
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class AutomationAccountHandler(ResourceHandler):
+    """Handler for Azure Automation Accounts.
+
+    Emits:
+        - azurerm_automation_account
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Automation/automationAccounts",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_automation_account",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Automation Account to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU (required)
+        sku = properties.get("sku", {})
+        config["sku_name"] = (
+            sku.get("name", "Basic") if isinstance(sku, dict) else "Basic"
+        )
+
+        logger.debug(f"Automation Account '{resource_name}' emitted")
+
+        return "azurerm_automation_account", safe_name, config

--- a/src/iac/emitters/terraform/handlers/automation/runbook.py
+++ b/src/iac/emitters/terraform/handlers/automation/runbook.py
@@ -1,0 +1,85 @@
+"""Automation Runbook handler for Terraform emission.
+
+Handles: Microsoft.Automation/automationAccounts/runbooks
+Emits: azurerm_automation_runbook
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class AutomationRunbookHandler(ResourceHandler):
+    """Handler for Azure Automation Runbooks.
+
+    Emits:
+        - azurerm_automation_runbook
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Automation/automationAccounts/runbooks",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_automation_runbook",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Automation Runbook to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        properties = self.parse_properties(resource)
+
+        # Extract automation account name and runbook name
+        full_name = resource_name
+        if "/" in full_name:
+            account_name = full_name.split("/")[0]
+            runbook_name = full_name.split("/")[1]
+        else:
+            account_name = "unknown-account"
+            runbook_name = full_name
+
+        safe_name = self.sanitize_name(runbook_name)
+
+        config = self.build_base_config(resource)
+        config["name"] = runbook_name
+
+        config.update(
+            {
+                "automation_account_name": account_name,
+                "runbook_type": properties.get("runbookType", "PowerShell"),
+                "log_progress": properties.get("logProgress", True),
+                "log_verbose": properties.get("logVerbose", False),
+            }
+        )
+
+        # Content link or content
+        publish_content_link = properties.get("publishContentLink", {})
+        if publish_content_link and "uri" in publish_content_link:
+            config["publish_content_link"] = {"uri": publish_content_link["uri"]}
+            if "version" in publish_content_link:
+                config["publish_content_link"]["version"] = publish_content_link[
+                    "version"
+                ]
+        else:
+            logger.warning(
+                f"Runbook '{runbook_name}' has no publishContentLink. "
+                "Using placeholder content."
+            )
+            config["content"] = (
+                "# Placeholder runbook content\n"
+                "# Original runbook content not available in graph\n"
+            )
+
+        logger.debug(f"Automation Runbook '{runbook_name}' emitted")
+
+        return "azurerm_automation_runbook", safe_name, config

--- a/src/iac/emitters/terraform/handlers/compute/__init__.py
+++ b/src/iac/emitters/terraform/handlers/compute/__init__.py
@@ -1,0 +1,15 @@
+"""Compute handlers for Terraform emission."""
+
+from .disks import ManagedDiskHandler, SnapshotHandler
+from .ssh_public_key import SSHPublicKeyHandler
+from .virtual_machine import VirtualMachineHandler
+from .vm_extensions import VMExtensionHandler, VMRunCommandHandler
+
+__all__ = [
+    "ManagedDiskHandler",
+    "SSHPublicKeyHandler",
+    "SnapshotHandler",
+    "VMExtensionHandler",
+    "VMRunCommandHandler",
+    "VirtualMachineHandler",
+]

--- a/src/iac/emitters/terraform/handlers/compute/disks.py
+++ b/src/iac/emitters/terraform/handlers/compute/disks.py
@@ -1,0 +1,112 @@
+"""Managed Disk and Snapshot handlers for Terraform emission.
+
+Handles: Microsoft.Compute/disks, Microsoft.Compute/snapshots
+Emits: azurerm_managed_disk, azurerm_snapshot
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ManagedDiskHandler(ResourceHandler):
+    """Handler for Azure Managed Disks.
+
+    Emits:
+        - azurerm_managed_disk
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Compute/disks",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_managed_disk",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Managed Disk to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Storage account type (required)
+        sku = properties.get("sku", {}) or resource.get("sku", {})
+        storage_account_type = (
+            sku.get("name", "Standard_LRS") if isinstance(sku, dict) else "Standard_LRS"
+        )
+        config["storage_account_type"] = storage_account_type
+
+        # Create option (required)
+        creation_data = properties.get("creationData", {})
+        create_option = creation_data.get("createOption", "Empty")
+        config["create_option"] = create_option
+
+        # Disk size
+        disk_size_gb = properties.get("diskSizeGB") or resource.get("diskSizeGB")
+        if disk_size_gb:
+            config["disk_size_gb"] = disk_size_gb
+
+        # OS type (optional)
+        os_type = properties.get("osType")
+        if os_type:
+            config["os_type"] = os_type
+
+        logger.debug(f"Managed Disk '{resource_name}' emitted")
+
+        return "azurerm_managed_disk", safe_name, config
+
+
+@handler
+class SnapshotHandler(ResourceHandler):
+    """Handler for Azure Disk Snapshots.
+
+    Emits:
+        - azurerm_snapshot
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Compute/snapshots",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_snapshot",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Snapshot to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Create option (required)
+        creation_data = properties.get("creationData", {})
+        create_option = creation_data.get("createOption", "Copy")
+        config["create_option"] = create_option
+
+        # Source disk ID (for Copy create option)
+        source_disk_id = creation_data.get("sourceResourceId")
+        if source_disk_id:
+            config["source_resource_id"] = source_disk_id
+
+        logger.debug(f"Snapshot '{resource_name}' emitted")
+
+        return "azurerm_snapshot", safe_name, config

--- a/src/iac/emitters/terraform/handlers/compute/ssh_public_key.py
+++ b/src/iac/emitters/terraform/handlers/compute/ssh_public_key.py
@@ -1,0 +1,54 @@
+"""SSH Public Key handler for Terraform emission.
+
+Handles: Microsoft.Compute/sshPublicKeys
+Emits: azurerm_ssh_public_key
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class SSHPublicKeyHandler(ResourceHandler):
+    """Handler for Azure SSH Public Keys.
+
+    Emits:
+        - azurerm_ssh_public_key
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Compute/sshPublicKeys",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_ssh_public_key",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure SSH Public Key to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Public key (required)
+        public_key = properties.get(
+            "publicKey",
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... placeholder",
+        )
+        config["public_key"] = public_key
+
+        logger.debug(f"SSH Public Key '{resource_name}' emitted")
+
+        return "azurerm_ssh_public_key", safe_name, config

--- a/src/iac/emitters/terraform/handlers/compute/virtual_machine.py
+++ b/src/iac/emitters/terraform/handlers/compute/virtual_machine.py
@@ -1,0 +1,183 @@
+"""Virtual Machine handler for Terraform emission.
+
+Handles: Microsoft.Compute/virtualMachines
+Emits: azurerm_linux_virtual_machine, tls_private_key
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class VirtualMachineHandler(ResourceHandler):
+    """Handler for Azure Virtual Machines.
+
+    Emits:
+        - azurerm_linux_virtual_machine
+        - tls_private_key (helper resource for SSH authentication)
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Compute/virtualMachines",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_linux_virtual_machine",
+        "azurerm_windows_virtual_machine",
+        "tls_private_key",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure VM to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+        """
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        # Validate network interfaces FIRST
+        nic_refs = self._validate_and_get_nics(resource, properties, context)
+        if not nic_refs:
+            logger.warning(
+                f"VM '{resource_name}' - all NIC references are missing. "
+                f"Skipping VM (cannot create without valid network configuration)."
+            )
+            return None
+
+        # Build base configuration
+        config = self.build_base_config(resource)
+
+        # Generate SSH key pair for VM authentication
+        ssh_key_resource_name = f"{safe_name}_ssh_key"
+
+        # Add tls_private_key resource to terraform config
+        context.add_helper_resource(
+            "tls_private_key",
+            ssh_key_resource_name,
+            {
+                "algorithm": "RSA",
+                "rsa_bits": 4096,
+            },
+        )
+
+        # Add VM-specific properties
+        config.update(
+            {
+                "size": resource.get("size", "Standard_B2s"),
+                "admin_username": resource.get("admin_username", "azureuser"),
+                "admin_ssh_key": {
+                    "username": resource.get("admin_username", "azureuser"),
+                    "public_key": f"${{tls_private_key.{ssh_key_resource_name}.public_key_openssh}}",
+                },
+                "network_interface_ids": nic_refs,
+                "os_disk": {
+                    "caching": "ReadWrite",
+                    "storage_account_type": "Standard_LRS",
+                },
+                "source_image_reference": {
+                    "publisher": "Canonical",
+                    "offer": "0001-com-ubuntu-server-jammy",
+                    "sku": "22_04-lts",
+                    "version": "latest",
+                },
+            }
+        )
+
+        logger.debug(f"VM '{resource_name}' emitted with {len(nic_refs)} NIC(s)")
+
+        return "azurerm_linux_virtual_machine", safe_name, config
+
+    def _validate_and_get_nics(
+        self,
+        resource: Dict[str, Any],
+        properties: Dict[str, Any],
+        context: EmitterContext,
+    ) -> list:
+        """Validate and collect NIC references.
+
+        Args:
+            resource: Azure resource dict
+            properties: Parsed properties dict
+            context: Emitter context
+
+        Returns:
+            List of valid NIC Terraform references
+        """
+        resource_name = resource.get("name", "unknown")
+        network_profile = properties.get("networkProfile", {})
+        nics = network_profile.get("networkInterfaces", [])
+
+        if not nics:
+            logger.warning(
+                f"VM '{resource_name}' has no networkProfile. "
+                f"Cannot create without valid network configuration."
+            )
+            return []
+
+        nic_refs = []
+        missing_nics = []
+
+        for nic in nics:
+            nic_id = nic.get("id", "")
+            if not nic_id:
+                continue
+
+            nic_name = self.extract_name_from_id(nic_id, "networkInterfaces")
+            if nic_name == "unknown":
+                continue
+
+            nic_safe = self.sanitize_name(nic_name)
+
+            # Bug #30: Validate NIC was actually emitted
+            if self.validate_resource_reference(
+                "azurerm_network_interface", nic_safe, context
+            ):
+                nic_refs.append(f"${{azurerm_network_interface.{nic_safe}.id}}")
+            else:
+                missing_nics.append(
+                    {
+                        "nic_name": nic_name,
+                        "nic_id": nic_id,
+                        "nic_terraform_name": nic_safe,
+                    }
+                )
+                context.track_missing_reference(
+                    resource_name,
+                    "network_interface",
+                    nic_name,
+                    nic_id,
+                    vm_name=resource_name,
+                    vm_id=resource.get("id", ""),
+                )
+
+        if missing_nics:
+            for missing in missing_nics:
+                logger.warning(
+                    f"VM '{resource_name}' references missing NIC '{missing['nic_name']}'\n"
+                    f"    Azure ID: {missing['nic_id']}\n"
+                    f"    Expected Terraform name: {missing['nic_terraform_name']}"
+                )
+
+            if nic_refs:
+                logger.info(
+                    f"VM '{resource_name}' will be created with {len(nic_refs)} valid NIC(s), "
+                    f"skipping {len(missing_nics)} missing NIC(s)"
+                )
+
+        return nic_refs

--- a/src/iac/emitters/terraform/handlers/compute/vm_extensions.py
+++ b/src/iac/emitters/terraform/handlers/compute/vm_extensions.py
@@ -1,0 +1,125 @@
+"""VM Extensions handler for Terraform emission.
+
+Handles: Microsoft.Compute/virtualMachines/extensions, runCommands
+Emits: azurerm_virtual_machine_extension, azurerm_virtual_machine_run_command
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class VMExtensionHandler(ResourceHandler):
+    """Handler for Azure VM Extensions.
+
+    Emits:
+        - azurerm_virtual_machine_extension
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Compute/virtualMachines/extensions",
+        "microsoft.compute/virtualMachines/extensions",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_virtual_machine_extension",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure VM Extension to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        # Extract VM name from extension name (format: "vmname/extensionname")
+        full_name = resource_name
+        if "/" in full_name:
+            vm_name = full_name.split("/")[0]
+            extension_name = full_name.split("/")[1]
+        else:
+            vm_name = "unknown-vm"
+            extension_name = full_name
+
+        vm_safe = self.sanitize_name(vm_name)
+
+        config = {
+            "name": extension_name,
+            "virtual_machine_id": f"${{azurerm_linux_virtual_machine.{vm_safe}.id}}",
+            "publisher": properties.get("publisher", "Microsoft.Azure.Extensions"),
+            "type": properties.get("type", "CustomScript"),
+            "type_handler_version": properties.get("typeHandlerVersion", "2.1"),
+        }
+
+        # Add auto upgrade
+        auto_upgrade = properties.get("autoUpgradeMinorVersion")
+        if auto_upgrade is not None:
+            config["auto_upgrade_minor_version"] = auto_upgrade
+
+        logger.debug(f"VM Extension '{extension_name}' emitted for VM '{vm_name}'")
+
+        return "azurerm_virtual_machine_extension", safe_name, config
+
+
+@handler
+class VMRunCommandHandler(ResourceHandler):
+    """Handler for Azure VM Run Commands.
+
+    Emits:
+        - azurerm_virtual_machine_run_command
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Compute/virtualMachines/runCommands",
+        "microsoft.compute/virtualmachines/runcommands",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_virtual_machine_run_command",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure VM Run Command to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        # Extract VM name from run command name (format: "vmname/runcommandname")
+        full_name = resource_name
+        if "/" in full_name:
+            vm_name = full_name.split("/")[0]
+            command_name = full_name.split("/")[1]
+        else:
+            vm_name = "unknown-vm"
+            command_name = full_name
+
+        vm_safe = self.sanitize_name(vm_name)
+        location = self.get_location(resource)
+
+        config = {
+            "name": command_name,
+            "location": location,
+            "virtual_machine_id": f"${{azurerm_linux_virtual_machine.{vm_safe}.id}}",
+        }
+
+        # Add source script
+        source = properties.get("source", {})
+        if source and "script" in source:
+            config["source"] = {"script": source["script"]}
+
+        logger.debug(f"VM Run Command '{command_name}' emitted for VM '{vm_name}'")
+
+        return "azurerm_virtual_machine_run_command", safe_name, config

--- a/src/iac/emitters/terraform/handlers/container/__init__.py
+++ b/src/iac/emitters/terraform/handlers/container/__init__.py
@@ -1,0 +1,14 @@
+"""Container handlers for Terraform emission."""
+
+from .aks import AKSHandler
+from .container_app import ContainerAppEnvironmentHandler, ContainerAppHandler
+from .container_group import ContainerGroupHandler
+from .container_registry import ContainerRegistryHandler
+
+__all__ = [
+    "AKSHandler",
+    "ContainerAppEnvironmentHandler",
+    "ContainerAppHandler",
+    "ContainerGroupHandler",
+    "ContainerRegistryHandler",
+]

--- a/src/iac/emitters/terraform/handlers/container/aks.py
+++ b/src/iac/emitters/terraform/handlers/container/aks.py
@@ -1,0 +1,70 @@
+"""AKS handler for Terraform emission.
+
+Handles: Microsoft.ContainerService/managedClusters
+Emits: azurerm_kubernetes_cluster
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class AKSHandler(ResourceHandler):
+    """Handler for Azure Kubernetes Service clusters.
+
+    Emits:
+        - azurerm_kubernetes_cluster
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.ContainerService/managedClusters",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_kubernetes_cluster",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert AKS cluster to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # DNS prefix
+        dns_prefix = properties.get("dnsPrefix", resource_name)
+        config["dns_prefix"] = dns_prefix
+
+        # Default node pool (required)
+        agent_pool_profiles = properties.get("agentPoolProfiles", [])
+        if agent_pool_profiles:
+            pool = agent_pool_profiles[0]
+            config["default_node_pool"] = {
+                "name": pool.get("name", "default"),
+                "node_count": pool.get("count", 1),
+                "vm_size": pool.get("vmSize", "Standard_DS2_v2"),
+            }
+        else:
+            config["default_node_pool"] = {
+                "name": "default",
+                "node_count": 1,
+                "vm_size": "Standard_DS2_v2",
+            }
+
+        # Identity
+        config["identity"] = {"type": "SystemAssigned"}
+
+        logger.debug(f"AKS Cluster '{resource_name}' emitted")
+
+        return "azurerm_kubernetes_cluster", safe_name, config

--- a/src/iac/emitters/terraform/handlers/container/container_app.py
+++ b/src/iac/emitters/terraform/handlers/container/container_app.py
@@ -1,0 +1,115 @@
+"""Container App handlers for Terraform emission.
+
+Handles: Microsoft.App/containerApps, Microsoft.App/managedEnvironments
+Emits: azurerm_container_app, azurerm_container_app_environment
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ContainerAppEnvironmentHandler(ResourceHandler):
+    """Handler for Azure Container App Environments.
+
+    Emits:
+        - azurerm_container_app_environment
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.App/managedEnvironments",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_container_app_environment",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Container App Environment to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        config = self.build_base_config(resource)
+
+        logger.debug(f"Container App Environment '{resource_name}' emitted")
+
+        return "azurerm_container_app_environment", safe_name, config
+
+
+@handler
+class ContainerAppHandler(ResourceHandler):
+    """Handler for Azure Container Apps.
+
+    Emits:
+        - azurerm_container_app
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.App/containerApps",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_container_app",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Container App to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Container app environment ID
+        env_id = properties.get("managedEnvironmentId")
+        if env_id:
+            config["container_app_environment_id"] = env_id
+
+        # Revision mode
+        config["revision_mode"] = properties.get("configuration", {}).get(
+            "activeRevisionsMode", "Single"
+        )
+
+        # Template
+        template = properties.get("template", {})
+        containers = template.get("containers", [])
+        if containers:
+            container = containers[0]
+            config["template"] = {
+                "container": {
+                    "name": container.get("name", "container"),
+                    "image": container.get(
+                        "image",
+                        "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest",
+                    ),
+                    "cpu": container.get("resources", {}).get("cpu", 0.25),
+                    "memory": container.get("resources", {}).get("memory", "0.5Gi"),
+                }
+            }
+        else:
+            config["template"] = {
+                "container": {
+                    "name": "container",
+                    "image": "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest",
+                    "cpu": 0.25,
+                    "memory": "0.5Gi",
+                }
+            }
+
+        logger.debug(f"Container App '{resource_name}' emitted")
+
+        return "azurerm_container_app", safe_name, config

--- a/src/iac/emitters/terraform/handlers/container/container_group.py
+++ b/src/iac/emitters/terraform/handlers/container/container_group.py
@@ -1,0 +1,78 @@
+"""Container Group handler for Terraform emission.
+
+Handles: Microsoft.ContainerInstance/containerGroups
+Emits: azurerm_container_group
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ContainerGroupHandler(ResourceHandler):
+    """Handler for Azure Container Instances.
+
+    Emits:
+        - azurerm_container_group
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.ContainerInstance/containerGroups",
+        "microsoft.containerinstance/containergroups",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_container_group",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Container Group to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # OS type (required)
+        os_type = properties.get("osType", "Linux")
+        config["os_type"] = os_type
+
+        # Container block (required)
+        containers = properties.get("containers", [])
+        if containers and len(containers) > 0:
+            container = containers[0]
+            container_props = container.get("properties", {})
+            resources = container_props.get("resources", {})
+            requests = resources.get("requests", {})
+
+            config["container"] = {
+                "name": container.get("name", "container"),
+                "image": container_props.get(
+                    "image", "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
+                ),
+                "cpu": str(requests.get("cpu", "0.5")),
+                "memory": str(requests.get("memoryInGB", "1.5")),
+            }
+        else:
+            config["container"] = {
+                "name": "container",
+                "image": "mcr.microsoft.com/azuredocs/aci-helloworld:latest",
+                "cpu": "0.5",
+                "memory": "1.5",
+            }
+
+        logger.debug(
+            f"Container Group '{resource_name}' emitted with os_type='{os_type}'"
+        )
+
+        return "azurerm_container_group", safe_name, config

--- a/src/iac/emitters/terraform/handlers/container/container_registry.py
+++ b/src/iac/emitters/terraform/handlers/container/container_registry.py
@@ -1,0 +1,57 @@
+"""Container Registry handler for Terraform emission.
+
+Handles: Microsoft.ContainerRegistry/registries
+Emits: azurerm_container_registry
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ContainerRegistryHandler(ResourceHandler):
+    """Handler for Azure Container Registries.
+
+    Emits:
+        - azurerm_container_registry
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.ContainerRegistry/registries",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_container_registry",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Container Registry to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU (required)
+        sku = properties.get("sku", {})
+        sku_name = sku.get("name", "Basic") if isinstance(sku, dict) else "Basic"
+        config["sku"] = sku_name
+
+        # Admin enabled
+        admin_enabled = properties.get("adminUserEnabled", False)
+        if admin_enabled:
+            config["admin_enabled"] = True
+
+        logger.debug(f"Container Registry '{resource_name}' emitted")
+
+        return "azurerm_container_registry", safe_name, config

--- a/src/iac/emitters/terraform/handlers/database/__init__.py
+++ b/src/iac/emitters/terraform/handlers/database/__init__.py
@@ -1,0 +1,13 @@
+"""Database handlers for Terraform emission."""
+
+from .cosmosdb import CosmosDBHandler
+from .postgresql import PostgreSQLFlexibleServerHandler
+from .sql_database import SQLDatabaseHandler
+from .sql_server import SQLServerHandler
+
+__all__ = [
+    "CosmosDBHandler",
+    "PostgreSQLFlexibleServerHandler",
+    "SQLDatabaseHandler",
+    "SQLServerHandler",
+]

--- a/src/iac/emitters/terraform/handlers/database/cosmosdb.py
+++ b/src/iac/emitters/terraform/handlers/database/cosmosdb.py
@@ -1,0 +1,78 @@
+"""Cosmos DB handler for Terraform emission.
+
+Handles: Microsoft.DocumentDB/databaseAccounts
+Emits: azurerm_cosmosdb_account
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class CosmosDBHandler(ResourceHandler):
+    """Handler for Azure Cosmos DB Accounts.
+
+    Emits:
+        - azurerm_cosmosdb_account
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.DocumentDB/databaseAccounts",
+        "Microsoft.DocumentDb/databaseAccounts",
+        "microsoft.documentdb/databaseaccounts",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_cosmosdb_account",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Cosmos DB Account to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Required: offer_type
+        config["offer_type"] = "Standard"
+
+        # Required: consistency_policy block
+        consistency = properties.get("consistencyPolicy", {})
+        config["consistency_policy"] = {
+            "consistency_level": consistency.get("defaultConsistencyLevel", "Session"),
+            "max_interval_in_seconds": consistency.get("maxIntervalInSeconds", 5),
+            "max_staleness_prefix": consistency.get("maxStalenessPrefix", 100),
+        }
+
+        # Required: geo_location block
+        locations = properties.get("locations", [])
+        location = self.get_location(resource)
+
+        if locations:
+            config["geo_location"] = [
+                {
+                    "location": loc.get("locationName", location).lower(),
+                    "failover_priority": loc.get("failoverPriority", 0),
+                }
+                for loc in locations
+            ]
+        else:
+            config["geo_location"] = [{"location": location, "failover_priority": 0}]
+
+        logger.debug(
+            f"Cosmos DB '{resource_name}' emitted with "
+            f"{len(config.get('geo_location', []))} locations"
+        )
+
+        return "azurerm_cosmosdb_account", safe_name, config

--- a/src/iac/emitters/terraform/handlers/database/postgresql.py
+++ b/src/iac/emitters/terraform/handlers/database/postgresql.py
@@ -1,0 +1,62 @@
+"""PostgreSQL Flexible Server handler for Terraform emission.
+
+Handles: Microsoft.DBforPostgreSQL/flexibleServers
+Emits: azurerm_postgresql_flexible_server
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class PostgreSQLFlexibleServerHandler(ResourceHandler):
+    """Handler for Azure PostgreSQL Flexible Servers.
+
+    Emits:
+        - azurerm_postgresql_flexible_server
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.DBforPostgreSQL/flexibleServers",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_postgresql_flexible_server",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert PostgreSQL Flexible Server to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = properties.get("sku", {})
+        if sku and "name" in sku:
+            config["sku_name"] = sku["name"]
+
+        # Version
+        version = properties.get("version")
+        if version:
+            config["version"] = version
+
+        # Storage
+        storage = properties.get("storage", {})
+        if storage and "storageSizeGB" in storage:
+            config["storage_mb"] = storage["storageSizeGB"] * 1024
+
+        logger.debug(f"PostgreSQL Flexible Server '{resource_name}' emitted")
+
+        return "azurerm_postgresql_flexible_server", safe_name, config

--- a/src/iac/emitters/terraform/handlers/database/sql_database.py
+++ b/src/iac/emitters/terraform/handlers/database/sql_database.py
@@ -1,0 +1,77 @@
+"""SQL Database handler for Terraform emission.
+
+Handles: Microsoft.Sql/servers/databases
+Emits: azurerm_mssql_database
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class SQLDatabaseHandler(ResourceHandler):
+    """Handler for Azure SQL Databases.
+
+    Emits:
+        - azurerm_mssql_database
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Sql/servers/databases",
+        "microsoft.sql/servers/databases",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_mssql_database",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure SQL Database to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        # Extract parent server name from database ID
+        db_id = resource.get("id", "") or resource.get("original_id", "")
+        server_name = self.extract_name_from_id(db_id, "servers")
+
+        if server_name == "unknown":
+            logger.warning(
+                f"SQL Database '{resource_name}' has no parent server in ID: {db_id}. "
+                f"Skipping."
+            )
+            return None
+
+        server_safe = self.sanitize_name(server_name)
+
+        # SQL Database only needs server_id, not location/resource_group_name
+        config = {
+            "name": resource_name,
+            "server_id": f"${{azurerm_mssql_server.{server_safe}.id}}",
+        }
+
+        # SKU
+        sku = properties.get("sku", {})
+        if sku and "name" in sku:
+            config["sku_name"] = sku["name"]
+
+        # Max size
+        max_size = properties.get("maxSizeBytes")
+        if max_size:
+            config["max_size_gb"] = max_size // (1024 * 1024 * 1024)
+
+        logger.debug(
+            f"SQL Database '{resource_name}' emitted for server '{server_name}'"
+        )
+
+        return "azurerm_mssql_database", safe_name, config

--- a/src/iac/emitters/terraform/handlers/database/sql_server.py
+++ b/src/iac/emitters/terraform/handlers/database/sql_server.py
@@ -1,0 +1,74 @@
+"""SQL Server handler for Terraform emission.
+
+Handles: Microsoft.Sql/servers
+Emits: azurerm_mssql_server, random_password
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class SQLServerHandler(ResourceHandler):
+    """Handler for Azure SQL Servers.
+
+    Emits:
+        - azurerm_mssql_server
+        - random_password (helper resource)
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Sql/servers",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_mssql_server",
+        "random_password",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure SQL Server to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        # Generate a unique password for each SQL server
+        password_resource_name = f"{safe_name}_password"
+
+        # Add random_password resource
+        context.add_helper_resource(
+            "random_password",
+            password_resource_name,
+            {
+                "length": 20,
+                "special": True,
+                "override_special": "!@#$%&*()-_=+[]{}<>:?",
+                "min_lower": 1,
+                "min_upper": 1,
+                "min_numeric": 1,
+                "min_special": 1,
+            },
+        )
+
+        config = self.build_base_config(resource)
+
+        config.update(
+            {
+                "version": resource.get("version", "12.0"),
+                "administrator_login": resource.get("administrator_login", "sqladmin"),
+                "administrator_login_password": f"${{random_password.{password_resource_name}.result}}",
+            }
+        )
+
+        logger.debug(f"SQL Server '{resource_name}' emitted")
+
+        return "azurerm_mssql_server", safe_name, config

--- a/src/iac/emitters/terraform/handlers/devtest/__init__.py
+++ b/src/iac/emitters/terraform/handlers/devtest/__init__.py
@@ -1,0 +1,11 @@
+"""DevTest handlers for Terraform emission."""
+
+from .devtest_lab import DevTestLabHandler
+from .devtest_schedule import DevTestScheduleHandler
+from .devtest_vm import DevTestVMHandler
+
+__all__ = [
+    "DevTestLabHandler",
+    "DevTestScheduleHandler",
+    "DevTestVMHandler",
+]

--- a/src/iac/emitters/terraform/handlers/devtest/devtest_lab.py
+++ b/src/iac/emitters/terraform/handlers/devtest/devtest_lab.py
@@ -1,0 +1,47 @@
+"""DevTest Lab handler for Terraform emission.
+
+Handles: Microsoft.DevTestLab/labs
+Emits: azurerm_dev_test_lab
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class DevTestLabHandler(ResourceHandler):
+    """Handler for Azure DevTest Labs.
+
+    Emits:
+        - azurerm_dev_test_lab
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.DevTestLab/labs",
+        "microsoft.devtestlab/labs",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_dev_test_lab",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert DevTest Lab to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        config = self.build_base_config(resource)
+
+        logger.debug(f"DevTest Lab '{resource_name}' emitted")
+
+        return "azurerm_dev_test_lab", safe_name, config

--- a/src/iac/emitters/terraform/handlers/devtest/devtest_schedule.py
+++ b/src/iac/emitters/terraform/handlers/devtest/devtest_schedule.py
@@ -1,0 +1,80 @@
+"""DevTest Schedule handler for Terraform emission.
+
+Handles: Microsoft.DevTestLab/schedules
+Emits: azurerm_dev_test_schedule
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class DevTestScheduleHandler(ResourceHandler):
+    """Handler for DevTest Lab Schedules.
+
+    Emits:
+        - azurerm_dev_test_schedule
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.DevTestLab/schedules",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_dev_test_schedule",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert DevTest Schedule to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        properties = self.parse_properties(resource)
+
+        # Extract lab and schedule names
+        full_name = resource_name
+        parts = full_name.split("/")
+        if len(parts) >= 3:
+            lab_name = parts[0]
+            schedule_name = parts[2]
+        else:
+            lab_name = "unknown-lab"
+            schedule_name = full_name
+
+        safe_name = self.sanitize_name(schedule_name)
+
+        config = self.build_base_config(resource)
+        config["name"] = schedule_name
+
+        # Schedule properties
+        task_type = properties.get("taskType", "LabVmsShutdownTask")
+        time_zone_id = properties.get("timeZoneId", "UTC")
+        daily_recurrence_time = properties.get("dailyRecurrence", {}).get(
+            "time", "1900"
+        )
+
+        config.update(
+            {
+                "lab_name": lab_name,
+                "task_type": task_type,
+                "time_zone_id": time_zone_id,
+                "daily_recurrence": {"time": daily_recurrence_time},
+                "notification_settings": {
+                    "time_in_minutes": properties.get("notificationSettings", {}).get(
+                        "timeInMinutes", 30
+                    ),
+                },
+            }
+        )
+
+        logger.debug(f"DevTest Schedule '{schedule_name}' emitted for lab '{lab_name}'")
+
+        return "azurerm_dev_test_schedule", safe_name, config

--- a/src/iac/emitters/terraform/handlers/devtest/devtest_vm.py
+++ b/src/iac/emitters/terraform/handlers/devtest/devtest_vm.py
@@ -1,0 +1,99 @@
+"""DevTest VM handler for Terraform emission.
+
+Handles: Microsoft.DevTestLab/labs/virtualMachines
+Emits: azurerm_dev_test_linux_virtual_machine
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class DevTestVMHandler(ResourceHandler):
+    """Handler for DevTest Lab Virtual Machines.
+
+    Emits:
+        - azurerm_dev_test_linux_virtual_machine
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.DevTestLab/labs/virtualMachines",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_dev_test_linux_virtual_machine",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert DevTest VM to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        properties = self.parse_properties(resource)
+
+        # Extract lab and VM names
+        full_name = resource_name
+        if "/" in full_name:
+            lab_name = full_name.split("/")[0]
+            vm_name = full_name.split("/")[1]
+        else:
+            lab_name = "unknown-lab"
+            vm_name = full_name
+
+        safe_name = self.sanitize_name(vm_name)
+
+        config = self.build_base_config(resource)
+        config["name"] = vm_name
+
+        # VM properties
+        size = properties.get("size", "Standard_DS1_v2")
+        username = properties.get("userName", "labuser")
+        storage_type = properties.get("storageType", "Standard")
+        lab_subnet_name = properties.get("labSubnetName", "default")
+
+        rg_name = self.get_resource_group(resource)
+        sub_id = context.get_effective_subscription_id(resource)
+
+        # Virtual network ID
+        lab_virtual_network_id = properties.get("labVirtualNetworkId")
+        if not lab_virtual_network_id:
+            lab_virtual_network_id = (
+                f"/subscriptions/{sub_id}/resourceGroups/{rg_name}/"
+                f"providers/Microsoft.DevTestLab/labs/{lab_name}/"
+                f"virtualnetworks/{lab_name}Vnet"
+            )
+
+        # Gallery image reference
+        gallery_image_ref = properties.get("galleryImageReference", {})
+
+        config.update(
+            {
+                "lab_name": lab_name,
+                "size": size,
+                "username": username,
+                "storage_type": storage_type,
+                "lab_subnet_name": lab_subnet_name,
+                "lab_virtual_network_id": lab_virtual_network_id,
+                "ssh_key": f"var.devtest_vm_ssh_key_{safe_name}",
+                "gallery_image_reference": {
+                    "offer": gallery_image_ref.get(
+                        "offer", "0001-com-ubuntu-server-jammy"
+                    ),
+                    "publisher": gallery_image_ref.get("publisher", "Canonical"),
+                    "sku": gallery_image_ref.get("sku", "22_04-lts-gen2"),
+                    "version": gallery_image_ref.get("version", "latest"),
+                },
+            }
+        )
+
+        logger.debug(f"DevTest VM '{vm_name}' emitted for lab '{lab_name}'")
+
+        return "azurerm_dev_test_linux_virtual_machine", safe_name, config

--- a/src/iac/emitters/terraform/handlers/identity/__init__.py
+++ b/src/iac/emitters/terraform/handlers/identity/__init__.py
@@ -1,0 +1,15 @@
+"""Identity handlers for Terraform emission."""
+
+from .entra_group import EntraGroupHandler
+from .entra_user import EntraUserHandler
+from .managed_identity import ManagedIdentityHandler
+from .role_assignment import RoleAssignmentHandler
+from .service_principal import ServicePrincipalHandler
+
+__all__ = [
+    "EntraGroupHandler",
+    "EntraUserHandler",
+    "ManagedIdentityHandler",
+    "RoleAssignmentHandler",
+    "ServicePrincipalHandler",
+]

--- a/src/iac/emitters/terraform/handlers/identity/entra_group.py
+++ b/src/iac/emitters/terraform/handlers/identity/entra_group.py
@@ -1,0 +1,62 @@
+"""Entra ID Group handler for Terraform emission.
+
+Handles: Group, Microsoft.AAD/Group, Microsoft.Graph/groups
+Emits: azuread_group
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class EntraGroupHandler(ResourceHandler):
+    """Handler for Entra ID (Azure AD) Groups.
+
+    Emits:
+        - azuread_group
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Group",
+        "Microsoft.AAD/Group",
+        "Microsoft.Graph/groups",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azuread_group",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Entra ID group to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        display_name = (
+            resource.get("displayName") or resource.get("display_name") or resource_name
+        )
+        mail_enabled = resource.get("mailEnabled", False)
+        security_enabled = resource.get("securityEnabled", True)
+
+        config = {
+            "display_name": display_name,
+            "mail_enabled": mail_enabled,
+            "security_enabled": security_enabled,
+        }
+
+        # Add description if present
+        if resource.get("description"):
+            config["description"] = resource.get("description")
+
+        logger.debug(f"Entra ID Group '{display_name}' emitted")
+
+        return "azuread_group", safe_name, config

--- a/src/iac/emitters/terraform/handlers/identity/entra_user.py
+++ b/src/iac/emitters/terraform/handlers/identity/entra_user.py
@@ -1,0 +1,84 @@
+"""Entra ID User handler for Terraform emission.
+
+Handles: User, Microsoft.AAD/User, Microsoft.Graph/users
+Emits: azuread_user
+"""
+
+import logging
+import re
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class EntraUserHandler(ResourceHandler):
+    """Handler for Entra ID (Azure AD) Users.
+
+    Emits:
+        - azuread_user
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "User",
+        "Microsoft.AAD/User",
+        "Microsoft.Graph/users",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azuread_user",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Entra ID user to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+
+        # Get UPN with sanitization
+        raw_upn = resource.get("userPrincipalName") or resource.get("name", "unknown")
+        upn = self._sanitize_upn(raw_upn)
+
+        safe_name = self.sanitize_name(resource_name)
+
+        display_name = (
+            resource.get("displayName") or resource.get("display_name") or upn
+        )
+        mail_nickname = (
+            resource.get("mailNickname")
+            or resource.get("mail_nickname")
+            or upn.split("@")[0]
+        )
+
+        config = {
+            "user_principal_name": upn,
+            "display_name": display_name,
+            "mail_nickname": mail_nickname,
+            "password": f"var.azuread_user_password_{safe_name}",
+            "force_password_change": True,
+        }
+
+        # Optional properties
+        if resource.get("accountEnabled") is not None:
+            config["account_enabled"] = resource.get("accountEnabled")
+
+        logger.debug(f"Entra ID User '{upn}' emitted")
+
+        return "azuread_user", safe_name, config
+
+    @staticmethod
+    def _sanitize_upn(upn: str) -> str:
+        """Sanitize user principal name.
+
+        Bug #32 fix: Remove spaces and normalize UPN.
+        """
+        upn = upn.strip()
+        upn = re.sub(r"\s+", " ", upn)
+        upn = upn.replace(" ", "_")
+        return upn

--- a/src/iac/emitters/terraform/handlers/identity/managed_identity.py
+++ b/src/iac/emitters/terraform/handlers/identity/managed_identity.py
@@ -1,0 +1,47 @@
+"""Managed Identity handler for Terraform emission.
+
+Handles: Microsoft.ManagedIdentity/userAssignedIdentities
+Emits: azurerm_user_assigned_identity
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ManagedIdentityHandler(ResourceHandler):
+    """Handler for User Assigned Managed Identities.
+
+    Emits:
+        - azurerm_user_assigned_identity
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.ManagedIdentity/userAssignedIdentities",
+        "Microsoft.ManagedIdentity/managedIdentities",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_user_assigned_identity",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Managed Identity to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        config = self.build_base_config(resource)
+
+        logger.debug(f"Managed Identity '{resource_name}' emitted")
+
+        return "azurerm_user_assigned_identity", safe_name, config

--- a/src/iac/emitters/terraform/handlers/identity/role_assignment.py
+++ b/src/iac/emitters/terraform/handlers/identity/role_assignment.py
@@ -1,0 +1,148 @@
+"""Role Assignment handler for Terraform emission.
+
+Handles: Microsoft.Authorization/roleAssignments
+Emits: azurerm_role_assignment
+"""
+
+import logging
+import re
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class RoleAssignmentHandler(ResourceHandler):
+    """Handler for Azure Role Assignments.
+
+    Emits:
+        - azurerm_role_assignment
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Authorization/roleAssignments",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_role_assignment",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Role Assignment to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        # Get scope and translate subscription ID for cross-tenant deployments
+        scope = properties.get("scope", resource.get("scope", ""))
+
+        # Translate subscription IDs in scope
+        if context.target_subscription_id and scope:
+            # Bug #59: Also replace ABSTRACT_SUBSCRIPTION placeholder
+            scope = re.sub(
+                r"/subscriptions/([a-f0-9-]+|ABSTRACT_SUBSCRIPTION)(/|$)",
+                f"/subscriptions/{context.target_subscription_id}\\2",
+                scope,
+                flags=re.IGNORECASE,
+            )
+            logger.debug("Translated role assignment scope for cross-tenant deployment")
+
+        # Translate role definition ID
+        role_def_id = properties.get(
+            "roleDefinitionId", resource.get("roleDefinitionId", "")
+        )
+        if context.target_subscription_id and role_def_id:
+            role_def_id = re.sub(
+                r"/subscriptions/([a-f0-9-]+|ABSTRACT_SUBSCRIPTION)/",
+                f"/subscriptions/{context.target_subscription_id}/",
+                role_def_id,
+                flags=re.IGNORECASE,
+            )
+
+        principal_id = properties.get("principalId", resource.get("principalId", ""))
+
+        # Bug #18: Skip role assignments without identity mapping in cross-tenant mode
+        if context.target_tenant_id and not context.identity_mapping:
+            logger.warning(
+                f"Skipping role assignment '{resource_name}' in cross-tenant mode: "
+                f"No identity mapping provided. Principal ID '{principal_id}' from source "
+                f"tenant cannot be validated in target tenant."
+            )
+            return None
+
+        # Bug #67: Translate principal_id using identity mapping
+        if context.identity_mapping and principal_id:
+            principal_type = properties.get("principalType", "Unknown")
+            translated_principal = self._translate_principal_id(
+                principal_id, principal_type, resource_name, context
+            )
+            if translated_principal:
+                logger.info(
+                    f"Translated role assignment principal_id: {principal_id} -> {translated_principal}"
+                )
+                principal_id = translated_principal
+            else:
+                logger.warning(
+                    f"Skipping role assignment '{resource_name}': "
+                    f"Principal ID '{principal_id}' not found in identity mapping"
+                )
+                return None
+
+        config = {
+            "scope": scope,
+            "role_definition_id": role_def_id,
+            "principal_id": principal_id,
+        }
+
+        # Note: Role assignments don't have location
+
+        logger.debug(f"Role Assignment '{resource_name}' emitted")
+
+        return "azurerm_role_assignment", safe_name, config
+
+    def _translate_principal_id(
+        self,
+        principal_id: str,
+        principal_type: str,
+        resource_name: str,
+        context: EmitterContext,
+    ) -> Optional[str]:
+        """Translate principal ID using identity mapping.
+
+        Args:
+            principal_id: Source principal ID
+            principal_type: Type of principal (User, Group, ServicePrincipal)
+            resource_name: Resource name for logging
+            context: Emitter context with identity mapping
+
+        Returns:
+            Translated principal ID or None if not found
+        """
+        if not context.identity_mapping:
+            return None
+
+        mapping = context.identity_mapping
+
+        # Try direct lookup in various mapping keys
+        for key in ["users", "groups", "servicePrincipals", "managedIdentities"]:
+            if key in mapping:
+                mapping_section = mapping[key]
+                if principal_id in mapping_section:
+                    return mapping_section[principal_id]
+
+        # Try case-insensitive lookup
+        for key in mapping:
+            if isinstance(mapping[key], dict):
+                for src_id, target_id in mapping[key].items():
+                    if src_id.lower() == principal_id.lower():
+                        return target_id
+
+        return None

--- a/src/iac/emitters/terraform/handlers/identity/service_principal.py
+++ b/src/iac/emitters/terraform/handlers/identity/service_principal.py
@@ -1,0 +1,73 @@
+"""Service Principal handler for Terraform emission.
+
+Handles: ServicePrincipal, Microsoft.AAD/ServicePrincipal, Microsoft.Graph/servicePrincipals
+Emits: azuread_service_principal
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ServicePrincipalHandler(ResourceHandler):
+    """Handler for Entra ID Service Principals.
+
+    Emits:
+        - azuread_service_principal
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "ServicePrincipal",
+        "Microsoft.AAD/ServicePrincipal",
+        "Microsoft.Graph/servicePrincipals",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azuread_service_principal",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Service Principal to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        # Bug #43: Try multiple field names for appId
+        app_id = (
+            resource.get("appId")
+            or resource.get("application_id")
+            or resource.get("applicationId")
+            or resource.get("client_id")
+        )
+
+        # Skip if no appId found
+        if not app_id:
+            logger.warning(
+                f"Skipping Service Principal '{resource_name}': No appId found. "
+                f"Available keys: {list(resource.keys())}"
+            )
+            return None
+
+        display_name = (
+            resource.get("displayName") or resource.get("display_name") or resource_name
+        )
+
+        config = {
+            "client_id": app_id,
+        }
+
+        # Add display_name as a comment (azuread_service_principal only needs client_id)
+        # The actual display_name comes from the linked application
+
+        logger.debug(f"Service Principal '{display_name}' (appId: {app_id}) emitted")
+
+        return "azuread_service_principal", safe_name, config

--- a/src/iac/emitters/terraform/handlers/keyvault/__init__.py
+++ b/src/iac/emitters/terraform/handlers/keyvault/__init__.py
@@ -1,0 +1,5 @@
+"""KeyVault handlers for Terraform emission."""
+
+from .vault import KeyVaultHandler
+
+__all__ = ["KeyVaultHandler"]

--- a/src/iac/emitters/terraform/handlers/keyvault/vault.py
+++ b/src/iac/emitters/terraform/handlers/keyvault/vault.py
@@ -1,0 +1,105 @@
+"""Key Vault handler for Terraform emission.
+
+Handles: Microsoft.KeyVault/vaults
+Emits: azurerm_key_vault
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class KeyVaultHandler(ResourceHandler):
+    """Handler for Azure Key Vaults.
+
+    Emits:
+        - azurerm_key_vault
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.KeyVault/vaults",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_key_vault",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Key Vault to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        properties = self.parse_properties(resource)
+
+        # Key Vaults need globally unique names with a suffix
+        resource_id = resource.get("id", "")
+
+        # Key Vaults have a 24-character name limit
+        # Suffix is 7 characters ("-XXXXXX"), so max base name is 17 chars
+        if len(resource_name) > 17:
+            truncated_name = resource_name[:17]
+            resource_name_with_suffix = self._add_unique_suffix(
+                truncated_name, resource_id
+            )
+            logger.warning(
+                f"Truncated Key Vault name '{resource_name}' to '{truncated_name}' "
+                f"for suffix, resulting in '{resource_name_with_suffix}'"
+            )
+        else:
+            resource_name_with_suffix = self._add_unique_suffix(
+                resource_name, resource_id
+            )
+
+        safe_name = self.sanitize_name(resource_name_with_suffix)
+
+        config = self.build_base_config(resource, resource_name_with_suffix)
+
+        # SKU (required)
+        sku = properties.get("sku", {})
+        sku_name = sku.get("name", "standard") if isinstance(sku, dict) else "standard"
+        config["sku_name"] = sku_name
+
+        # Tenant ID (required)
+        tenant_id = properties.get("tenantId") or context.target_tenant_id
+        if tenant_id:
+            config["tenant_id"] = tenant_id
+        else:
+            # Use variable reference
+            config["tenant_id"] = "${var.tenant_id}"
+
+        # Soft delete settings
+        soft_delete_enabled = properties.get("enableSoftDelete", True)
+        if soft_delete_enabled:
+            config["soft_delete_retention_days"] = properties.get(
+                "softDeleteRetentionInDays", 90
+            )
+
+        # Purge protection
+        purge_protection = properties.get("enablePurgeProtection", False)
+        if purge_protection:
+            config["purge_protection_enabled"] = True
+
+        logger.debug(
+            f"Key Vault '{resource_name}' -> '{resource_name_with_suffix}' emitted"
+        )
+
+        return "azurerm_key_vault", safe_name, config
+
+    def _add_unique_suffix(self, name: str, resource_id: str) -> str:
+        """Add a unique suffix based on resource ID hash."""
+        import hashlib
+
+        if not resource_id:
+            return name
+
+        # Generate 6-character hash from resource ID
+        hash_val = hashlib.md5(resource_id.encode()).hexdigest()[:6]
+        return f"{name}-{hash_val}"

--- a/src/iac/emitters/terraform/handlers/misc/__init__.py
+++ b/src/iac/emitters/terraform/handlers/misc/__init__.py
@@ -1,0 +1,34 @@
+"""Miscellaneous resource handlers for Terraform emission.
+
+This module contains handlers for various Azure resource types
+that don't fit into other categories.
+"""
+
+from .app_config import AppConfigurationHandler
+from .data_factory import DataFactoryHandler
+from .databricks import DatabricksWorkspaceHandler
+from .dns_zone import DNSZoneHandler, PrivateDNSZoneHandler
+from .eventhub import EventHubHandler, EventHubNamespaceHandler
+from .recovery_vault import RecoveryServicesVaultHandler
+from .redis import RedisCacheHandler
+from .resource_group import ResourceGroupHandler
+from .search_service import SearchServiceHandler
+from .servicebus import ServiceBusNamespaceHandler, ServiceBusQueueHandler
+from .waf_policy import WAFPolicyHandler
+
+__all__ = [
+    "AppConfigurationHandler",
+    "DNSZoneHandler",
+    "DataFactoryHandler",
+    "DatabricksWorkspaceHandler",
+    "EventHubHandler",
+    "EventHubNamespaceHandler",
+    "PrivateDNSZoneHandler",
+    "RecoveryServicesVaultHandler",
+    "RedisCacheHandler",
+    "ResourceGroupHandler",
+    "SearchServiceHandler",
+    "ServiceBusNamespaceHandler",
+    "ServiceBusQueueHandler",
+    "WAFPolicyHandler",
+]

--- a/src/iac/emitters/terraform/handlers/misc/app_config.py
+++ b/src/iac/emitters/terraform/handlers/misc/app_config.py
@@ -1,0 +1,96 @@
+"""App Configuration handler for Terraform emission.
+
+Handles: Microsoft.AppConfiguration/configurationStores
+Emits: azurerm_app_configuration
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class AppConfigurationHandler(ResourceHandler):
+    """Handler for Azure App Configuration.
+
+    Emits:
+        - azurerm_app_configuration
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.AppConfiguration/configurationStores",
+        "microsoft.appconfiguration/configurationstores",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_app_configuration",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert App Configuration to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = resource.get("sku", {})
+        config["sku"] = sku.get("name", "free") if isinstance(sku, dict) else "free"
+
+        # Public network access
+        if properties.get("publicNetworkAccess"):
+            config["public_network_access"] = properties.get("publicNetworkAccess")
+
+        # Soft delete retention
+        if properties.get("softDeleteRetentionInDays"):
+            config["soft_delete_retention_days"] = properties.get(
+                "softDeleteRetentionInDays"
+            )
+
+        # Purge protection
+        if properties.get("enablePurgeProtection") is not None:
+            config["purge_protection_enabled"] = properties.get("enablePurgeProtection")
+
+        # Local auth
+        if properties.get("disableLocalAuth") is not None:
+            config["local_auth_enabled"] = not properties.get("disableLocalAuth")
+
+        # Identity
+        identity = resource.get("identity", {})
+        if identity.get("type"):
+            identity_type = identity.get("type", "").lower()
+            if "systemassigned" in identity_type:
+                config["identity"] = {"type": "SystemAssigned"}
+            elif "userassigned" in identity_type:
+                user_ids = list(identity.get("userAssignedIdentities", {}).keys())
+                if user_ids:
+                    config["identity"] = {
+                        "type": "UserAssigned",
+                        "identity_ids": user_ids,
+                    }
+
+        # Encryption
+        encryption = properties.get("encryption", {})
+        if encryption.get("keyVaultProperties"):
+            kv_props = encryption["keyVaultProperties"]
+            config["encryption"] = {
+                "key_vault_key_identifier": kv_props.get("keyIdentifier", ""),
+            }
+            if kv_props.get("identityClientId"):
+                config["encryption"]["identity_client_id"] = kv_props.get(
+                    "identityClientId"
+                )
+
+        logger.debug(f"App Configuration '{resource_name}' emitted")
+
+        return "azurerm_app_configuration", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/data_factory.py
+++ b/src/iac/emitters/terraform/handlers/misc/data_factory.py
@@ -1,0 +1,108 @@
+"""Data Factory handler for Terraform emission.
+
+Handles: Microsoft.DataFactory/factories
+Emits: azurerm_data_factory
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class DataFactoryHandler(ResourceHandler):
+    """Handler for Azure Data Factory.
+
+    Emits:
+        - azurerm_data_factory
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.DataFactory/factories",
+        "microsoft.datafactory/factories",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_data_factory",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Data Factory to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Public network access
+        if properties.get("publicNetworkAccess"):
+            config["public_network_enabled"] = (
+                properties.get("publicNetworkAccess", "Enabled") == "Enabled"
+            )
+
+        # Managed virtual network
+        if properties.get("managedVirtualNetworkEnabled"):
+            config["managed_virtual_network_enabled"] = True
+
+        # Identity
+        identity = resource.get("identity", {})
+        if identity.get("type"):
+            identity_type = identity.get("type", "").lower()
+            if "systemassigned" in identity_type:
+                config["identity"] = {"type": "SystemAssigned"}
+            elif "userassigned" in identity_type:
+                user_ids = list(identity.get("userAssignedIdentities", {}).keys())
+                config["identity"] = {
+                    "type": "UserAssigned",
+                    "identity_ids": user_ids,
+                }
+
+        # Global parameters
+        global_params = properties.get("globalParameters", {})
+        if global_params:
+            tf_params = []
+            for name, param_config in global_params.items():
+                tf_params.append(
+                    {
+                        "name": name,
+                        "type": param_config.get("type", "String"),
+                        "value": str(param_config.get("value", "")),
+                    }
+                )
+            if tf_params:
+                config["global_parameter"] = tf_params
+
+        # Git configuration
+        repo_config = properties.get("repoConfiguration", {})
+        if repo_config:
+            repo_type = repo_config.get("type", "")
+            if "GitHub" in repo_type:
+                config["github_configuration"] = {
+                    "account_name": repo_config.get("accountName", ""),
+                    "branch_name": repo_config.get("collaborationBranch", "main"),
+                    "repository_name": repo_config.get("repositoryName", ""),
+                    "root_folder": repo_config.get("rootFolder", "/"),
+                    "git_url": repo_config.get("hostName", "https://github.com"),
+                }
+            elif "AzureDevOps" in repo_type or "FactoryVSTS" in repo_type:
+                config["vsts_configuration"] = {
+                    "account_name": repo_config.get("accountName", ""),
+                    "branch_name": repo_config.get("collaborationBranch", "main"),
+                    "project_name": repo_config.get("projectName", ""),
+                    "repository_name": repo_config.get("repositoryName", ""),
+                    "root_folder": repo_config.get("rootFolder", "/"),
+                    "tenant_id": repo_config.get("tenantId", ""),
+                }
+
+        logger.debug(f"Data Factory '{resource_name}' emitted")
+
+        return "azurerm_data_factory", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/databricks.py
+++ b/src/iac/emitters/terraform/handlers/misc/databricks.py
@@ -1,0 +1,123 @@
+"""Databricks handler for Terraform emission.
+
+Handles: Microsoft.Databricks/workspaces
+Emits: azurerm_databricks_workspace
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class DatabricksWorkspaceHandler(ResourceHandler):
+    """Handler for Azure Databricks Workspaces.
+
+    Emits:
+        - azurerm_databricks_workspace
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Databricks/workspaces",
+        "microsoft.databricks/workspaces",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_databricks_workspace",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Databricks Workspace to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = resource.get("sku", {})
+        config["sku"] = (
+            sku.get("name", "standard") if isinstance(sku, dict) else "standard"
+        )
+
+        # Managed resource group
+        managed_rg_id = properties.get("managedResourceGroupId", "")
+        if managed_rg_id:
+            # Extract just the name
+            rg_name = (
+                managed_rg_id.split("/")[-1] if "/" in managed_rg_id else managed_rg_id
+            )
+            config["managed_resource_group_name"] = rg_name
+
+        # Public network access
+        if properties.get("publicNetworkAccess"):
+            config["public_network_access_enabled"] = (
+                properties.get("publicNetworkAccess", "Enabled") == "Enabled"
+            )
+
+        # Network security
+        if properties.get("requiredNsgRules"):
+            config["network_security_group_rules_required"] = properties.get(
+                "requiredNsgRules"
+            )
+
+        # Custom parameters for VNet injection
+        custom_params = properties.get("parameters", {})
+        if custom_params:
+            custom_params_config = {}
+
+            # VNet ID
+            if custom_params.get("customVirtualNetworkId", {}).get("value"):
+                custom_params_config["virtual_network_id"] = custom_params[
+                    "customVirtualNetworkId"
+                ]["value"]
+
+            # Public subnet
+            if custom_params.get("customPublicSubnetName", {}).get("value"):
+                custom_params_config["public_subnet_name"] = custom_params[
+                    "customPublicSubnetName"
+                ]["value"]
+
+            # Private subnet
+            if custom_params.get("customPrivateSubnetName", {}).get("value"):
+                custom_params_config["private_subnet_name"] = custom_params[
+                    "customPrivateSubnetName"
+                ]["value"]
+
+            # Public subnet NSG association
+            if custom_params.get("enableNoPublicIp", {}).get("value"):
+                custom_params_config["no_public_ip"] = True
+
+            if custom_params_config:
+                config["custom_parameters"] = custom_params_config
+
+        # Infrastructure encryption
+        if (
+            properties.get("encryption", {})
+            .get("entities", {})
+            .get("managedDisk", {})
+            .get("keySource")
+        ):
+            config["infrastructure_encryption_enabled"] = True
+
+        # Customer managed keys
+        encryption = properties.get("encryption", {})
+        if (
+            encryption.get("entities", {})
+            .get("managedServices", {})
+            .get("keyVaultProperties")
+        ):
+            config["customer_managed_key_enabled"] = True
+
+        logger.debug(f"Databricks Workspace '{resource_name}' emitted")
+
+        return "azurerm_databricks_workspace", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/dns_zone.py
+++ b/src/iac/emitters/terraform/handlers/misc/dns_zone.py
@@ -1,0 +1,80 @@
+"""DNS Zone handlers for Terraform emission.
+
+Handles: Microsoft.Network/dnsZones, Microsoft.Network/privateDnsZones
+Emits: azurerm_dns_zone, azurerm_private_dns_zone
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class DNSZoneHandler(ResourceHandler):
+    """Handler for Azure DNS Zones.
+
+    Emits:
+        - azurerm_dns_zone
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/dnsZones",
+        "microsoft.network/dnszones",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_dns_zone",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert DNS Zone to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        config = self.build_base_config(resource)
+
+        logger.debug(f"DNS Zone '{resource_name}' emitted")
+
+        return "azurerm_dns_zone", safe_name, config
+
+
+@handler
+class PrivateDNSZoneHandler(ResourceHandler):
+    """Handler for Azure Private DNS Zones.
+
+    Emits:
+        - azurerm_private_dns_zone
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/privateDnsZones",
+        "microsoft.network/privatednszones",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_private_dns_zone",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Private DNS Zone to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        config = self.build_base_config(resource)
+
+        logger.debug(f"Private DNS Zone '{resource_name}' emitted")
+
+        return "azurerm_private_dns_zone", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/eventhub.py
+++ b/src/iac/emitters/terraform/handlers/misc/eventhub.py
@@ -1,0 +1,115 @@
+"""Event Hub handlers for Terraform emission.
+
+Handles: Microsoft.EventHub/namespaces, Microsoft.EventHub/namespaces/eventhubs
+Emits: azurerm_eventhub_namespace, azurerm_eventhub
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class EventHubNamespaceHandler(ResourceHandler):
+    """Handler for Azure Event Hub Namespaces.
+
+    Emits:
+        - azurerm_eventhub_namespace
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.EventHub/namespaces",
+        "microsoft.eventhub/namespaces",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_eventhub_namespace",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Event Hub Namespace to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = properties.get("sku", {})
+        config["sku"] = (
+            sku.get("name", "Standard") if isinstance(sku, dict) else "Standard"
+        )
+        config["capacity"] = sku.get("capacity", 1) if isinstance(sku, dict) else 1
+
+        # Additional settings
+        config["auto_inflate_enabled"] = properties.get("isAutoInflateEnabled", False)
+        if config["auto_inflate_enabled"]:
+            config["maximum_throughput_units"] = properties.get(
+                "maximumThroughputUnits", 20
+            )
+
+        logger.debug(f"Event Hub Namespace '{resource_name}' emitted")
+
+        return "azurerm_eventhub_namespace", safe_name, config
+
+
+@handler
+class EventHubHandler(ResourceHandler):
+    """Handler for Azure Event Hubs.
+
+    Emits:
+        - azurerm_eventhub
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.EventHub/namespaces/eventhubs",
+        "microsoft.eventhub/namespaces/eventhubs",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_eventhub",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Event Hub to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        properties = self.parse_properties(resource)
+
+        # Extract namespace and hub names
+        full_name = resource_name
+        if "/" in full_name:
+            namespace_name = full_name.split("/")[0]
+            hub_name = full_name.split("/")[1]
+        else:
+            namespace_name = "unknown-namespace"
+            hub_name = full_name
+
+        safe_name = self.sanitize_name(hub_name)
+
+        config = self.build_base_config(resource)
+        config["name"] = hub_name
+
+        config.update(
+            {
+                "namespace_name": namespace_name,
+                "partition_count": properties.get("partitionCount", 2),
+                "message_retention": properties.get("messageRetentionInDays", 1),
+            }
+        )
+
+        logger.debug(f"Event Hub '{hub_name}' emitted for namespace '{namespace_name}'")
+
+        return "azurerm_eventhub", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/recovery_vault.py
+++ b/src/iac/emitters/terraform/handlers/misc/recovery_vault.py
@@ -1,0 +1,111 @@
+"""Recovery Services Vault handler for Terraform emission.
+
+Handles: Microsoft.RecoveryServices/vaults
+Emits: azurerm_recovery_services_vault
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class RecoveryServicesVaultHandler(ResourceHandler):
+    """Handler for Azure Recovery Services Vaults.
+
+    Emits:
+        - azurerm_recovery_services_vault
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.RecoveryServices/vaults",
+        "microsoft.recoveryservices/vaults",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_recovery_services_vault",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Recovery Services Vault to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = resource.get("sku", {})
+        config["sku"] = (
+            sku.get("name", "Standard") if isinstance(sku, dict) else "Standard"
+        )
+
+        # Soft delete
+        security_settings = properties.get("securitySettings", {})
+        soft_delete = security_settings.get("softDeleteSettings", {})
+        if soft_delete:
+            config["soft_delete_enabled"] = (
+                soft_delete.get("softDeleteState", "Enabled") == "Enabled"
+            )
+
+        # Cross region restore
+        if properties.get("redundancySettings", {}).get("crossRegionRestore"):
+            config["cross_region_restore_enabled"] = (
+                properties["redundancySettings"]["crossRegionRestore"] == "Enabled"
+            )
+
+        # Storage model type
+        redundancy_settings = properties.get("redundancySettings", {})
+        if redundancy_settings.get("standardTierStorageRedundancy"):
+            storage_type = redundancy_settings["standardTierStorageRedundancy"]
+            storage_type_map = {
+                "LocallyRedundant": "LocallyRedundant",
+                "GeoRedundant": "GeoRedundant",
+                "ZoneRedundant": "ZoneRedundant",
+            }
+            config["storage_mode_type"] = storage_type_map.get(
+                storage_type, "LocallyRedundant"
+            )
+
+        # Public network access
+        if properties.get("publicNetworkAccess"):
+            config["public_network_access_enabled"] = (
+                properties.get("publicNetworkAccess", "Enabled") == "Enabled"
+            )
+
+        # Immutability
+        immutability = security_settings.get("immutabilitySettings", {})
+        if immutability.get("state"):
+            config["immutability"] = immutability.get("state", "Disabled")
+
+        # Identity
+        identity = resource.get("identity", {})
+        if identity.get("type"):
+            identity_type = identity.get("type", "").lower()
+            if "systemassigned" in identity_type:
+                config["identity"] = {"type": "SystemAssigned"}
+
+        # Encryption
+        encryption = properties.get("encryption", {})
+        if encryption.get("keyVaultProperties"):
+            kv_props = encryption["keyVaultProperties"]
+            config["encryption"] = {
+                "key_id": kv_props.get("keyUri", ""),
+                "infrastructure_encryption_enabled": encryption.get(
+                    "infrastructureEncryption", "Disabled"
+                )
+                == "Enabled",
+            }
+
+        logger.debug(f"Recovery Services Vault '{resource_name}' emitted")
+
+        return "azurerm_recovery_services_vault", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/redis.py
+++ b/src/iac/emitters/terraform/handlers/misc/redis.py
@@ -1,0 +1,90 @@
+"""Redis Cache handler for Terraform emission.
+
+Handles: Microsoft.Cache/Redis
+Emits: azurerm_redis_cache
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class RedisCacheHandler(ResourceHandler):
+    """Handler for Azure Redis Cache.
+
+    Emits:
+        - azurerm_redis_cache
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Cache/Redis",
+        "microsoft.cache/redis",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_redis_cache",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Redis Cache to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU configuration
+        sku = properties.get("sku", {})
+        config["capacity"] = sku.get("capacity", 1) if isinstance(sku, dict) else 1
+        config["family"] = sku.get("family", "C") if isinstance(sku, dict) else "C"
+        config["sku_name"] = (
+            sku.get("name", "Standard") if isinstance(sku, dict) else "Standard"
+        )
+
+        # Redis version
+        config["redis_version"] = properties.get("redisVersion", "6")
+
+        # Non-SSL port
+        config["enable_non_ssl_port"] = properties.get("enableNonSslPort", False)
+
+        # Minimum TLS version
+        config["minimum_tls_version"] = properties.get("minimumTlsVersion", "1.2")
+
+        # Public network access
+        if properties.get("publicNetworkAccess"):
+            config["public_network_access_enabled"] = (
+                properties.get("publicNetworkAccess", "Enabled") == "Enabled"
+            )
+
+        # Redis configuration
+        redis_config = properties.get("redisConfiguration", {})
+        if redis_config:
+            tf_redis_config = {}
+            if redis_config.get("maxmemory-policy"):
+                tf_redis_config["maxmemory_policy"] = redis_config.get(
+                    "maxmemory-policy"
+                )
+            if redis_config.get("maxmemory-reserved"):
+                tf_redis_config["maxmemory_reserved"] = redis_config.get(
+                    "maxmemory-reserved"
+                )
+            if redis_config.get("maxfragmentationmemory-reserved"):
+                tf_redis_config["maxfragmentationmemory_reserved"] = redis_config.get(
+                    "maxfragmentationmemory-reserved"
+                )
+            if tf_redis_config:
+                config["redis_configuration"] = tf_redis_config
+
+        logger.debug(f"Redis Cache '{resource_name}' emitted")
+
+        return "azurerm_redis_cache", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/resource_group.py
+++ b/src/iac/emitters/terraform/handlers/misc/resource_group.py
@@ -1,0 +1,51 @@
+"""Resource Group handler for Terraform emission.
+
+Handles: Microsoft.Resources/resourceGroups
+Emits: azurerm_resource_group
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ResourceGroupHandler(ResourceHandler):
+    """Handler for Azure Resource Groups.
+
+    Emits:
+        - azurerm_resource_group
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Resources/resourceGroups",
+        "microsoft.resources/resourcegroups",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_resource_group",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Resource Group to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        config = {
+            "name": resource_name,
+            "location": self.get_location(resource),
+            "tags": self.parse_tags(resource),
+        }
+
+        logger.debug(f"Resource Group '{resource_name}' emitted")
+
+        return "azurerm_resource_group", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/search_service.py
+++ b/src/iac/emitters/terraform/handlers/misc/search_service.py
@@ -1,0 +1,102 @@
+"""Search Service handler for Terraform emission.
+
+Handles: Microsoft.Search/searchServices
+Emits: azurerm_search_service
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class SearchServiceHandler(ResourceHandler):
+    """Handler for Azure Cognitive Search Service.
+
+    Emits:
+        - azurerm_search_service
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Search/searchServices",
+        "microsoft.search/searchservices",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_search_service",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Search Service to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = resource.get("sku", {})
+        config["sku"] = (
+            sku.get("name", "standard") if isinstance(sku, dict) else "standard"
+        )
+
+        # Replica and partition count
+        if properties.get("replicaCount"):
+            config["replica_count"] = properties.get("replicaCount")
+        if properties.get("partitionCount"):
+            config["partition_count"] = properties.get("partitionCount")
+
+        # Public network access
+        if properties.get("publicNetworkAccess"):
+            config["public_network_access_enabled"] = (
+                properties.get("publicNetworkAccess", "enabled") == "enabled"
+            )
+
+        # Hosting mode
+        if properties.get("hostingMode"):
+            config["hosting_mode"] = properties.get("hostingMode", "default")
+
+        # Local authentication
+        if properties.get("disableLocalAuth") is not None:
+            config["local_authentication_enabled"] = not properties.get(
+                "disableLocalAuth"
+            )
+
+        # Semantic search
+        if properties.get("semanticSearch"):
+            config["semantic_search_sku"] = properties.get("semanticSearch")
+
+        # Allowed IPs (network rules)
+        network_rules = properties.get("networkRuleSet", {})
+        ip_rules = network_rules.get("ipRules", [])
+        if ip_rules:
+            config["allowed_ips"] = [
+                rule.get("value", "") for rule in ip_rules if rule.get("value")
+            ]
+
+        # Identity
+        identity = resource.get("identity", {})
+        if identity.get("type"):
+            identity_type = identity.get("type", "").lower()
+            if "systemassigned" in identity_type:
+                config["identity"] = {"type": "SystemAssigned"}
+
+        # Customer managed key
+        encryption = properties.get("encryptionWithCmk", {})
+        if encryption.get("enforcement"):
+            config["customer_managed_key_enforcement_enabled"] = (
+                encryption.get("enforcement") == "Enabled"
+            )
+
+        logger.debug(f"Search Service '{resource_name}' emitted")
+
+        return "azurerm_search_service", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/servicebus.py
+++ b/src/iac/emitters/terraform/handlers/misc/servicebus.py
@@ -1,0 +1,133 @@
+"""Service Bus handlers for Terraform emission.
+
+Handles: Microsoft.ServiceBus/namespaces, Microsoft.ServiceBus/namespaces/queues
+Emits: azurerm_servicebus_namespace, azurerm_servicebus_queue
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ServiceBusNamespaceHandler(ResourceHandler):
+    """Handler for Azure Service Bus Namespaces.
+
+    Emits:
+        - azurerm_servicebus_namespace
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.ServiceBus/namespaces",
+        "microsoft.servicebus/namespaces",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_servicebus_namespace",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Service Bus Namespace to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = properties.get("sku", {})
+        config["sku"] = (
+            sku.get("name", "Standard") if isinstance(sku, dict) else "Standard"
+        )
+
+        # Capacity for Premium SKU
+        if config["sku"] == "Premium":
+            config["capacity"] = sku.get("capacity", 1) if isinstance(sku, dict) else 1
+
+        # Premium features
+        if properties.get("zoneRedundant"):
+            config["zone_redundant"] = True
+        if properties.get("premiumMessagingPartitions"):
+            config["premium_messaging_partitions"] = properties.get(
+                "premiumMessagingPartitions"
+            )
+
+        logger.debug(f"Service Bus Namespace '{resource_name}' emitted")
+
+        return "azurerm_servicebus_namespace", safe_name, config
+
+
+@handler
+class ServiceBusQueueHandler(ResourceHandler):
+    """Handler for Azure Service Bus Queues.
+
+    Emits:
+        - azurerm_servicebus_queue
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.ServiceBus/namespaces/queues",
+        "microsoft.servicebus/namespaces/queues",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_servicebus_queue",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Service Bus Queue to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        properties = self.parse_properties(resource)
+
+        # Extract namespace and queue names
+        full_name = resource_name
+        if "/" in full_name:
+            namespace_name = full_name.split("/")[0]
+            queue_name = full_name.split("/")[1]
+        else:
+            namespace_name = "unknown-namespace"
+            queue_name = full_name
+
+        safe_name = self.sanitize_name(queue_name)
+
+        config = self.build_base_config(resource)
+        config["name"] = queue_name
+
+        config.update(
+            {
+                "namespace_id": f"${{azurerm_servicebus_namespace.{self.sanitize_name(namespace_name)}.id}}",
+                "enable_partitioning": properties.get("enablePartitioning", False),
+                "max_delivery_count": properties.get("maxDeliveryCount", 10),
+            }
+        )
+
+        # Optional settings
+        if properties.get("lockDuration"):
+            config["lock_duration"] = properties.get("lockDuration")
+        if properties.get("defaultMessageTimeToLive"):
+            config["default_message_ttl"] = properties.get("defaultMessageTimeToLive")
+        if properties.get("deadLetteringOnMessageExpiration"):
+            config["dead_lettering_on_message_expiration"] = True
+        if properties.get("requiresDuplicateDetection"):
+            config["requires_duplicate_detection"] = True
+        if properties.get("requiresSession"):
+            config["requires_session"] = True
+
+        logger.debug(
+            f"Service Bus Queue '{queue_name}' emitted for namespace '{namespace_name}'"
+        )
+
+        return "azurerm_servicebus_queue", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/waf_policy.py
+++ b/src/iac/emitters/terraform/handlers/misc/waf_policy.py
@@ -1,0 +1,129 @@
+"""WAF Policy handler for Terraform emission.
+
+Handles: Microsoft.Network/frontDoorWebApplicationFirewallPolicies,
+         Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies
+Emits: azurerm_frontdoor_firewall_policy, azurerm_web_application_firewall_policy
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class WAFPolicyHandler(ResourceHandler):
+    """Handler for Azure WAF Policies.
+
+    Handles both Front Door and Application Gateway WAF policies.
+
+    Emits:
+        - azurerm_frontdoor_firewall_policy (for Front Door)
+        - azurerm_web_application_firewall_policy (for App Gateway)
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/frontDoorWebApplicationFirewallPolicies",
+        "microsoft.network/frontdoorwebapplicationfirewallpolicies",
+        "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies",
+        "microsoft.network/applicationgatewaywebapplicationfirewallpolicies",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_frontdoor_firewall_policy",
+        "azurerm_web_application_firewall_policy",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert WAF Policy to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+        azure_type = resource.get("type", "").lower()
+
+        config = self.build_base_config(resource)
+
+        # Determine if Front Door or App Gateway
+        is_frontdoor = "frontdoor" in azure_type
+
+        if is_frontdoor:
+            terraform_type = "azurerm_frontdoor_firewall_policy"
+            config["enabled"] = (
+                properties.get("policySettings", {}).get("enabledState", "Enabled")
+                == "Enabled"
+            )
+            config["mode"] = properties.get("policySettings", {}).get(
+                "mode", "Prevention"
+            )
+        else:
+            terraform_type = "azurerm_web_application_firewall_policy"
+            # Policy settings
+            policy_settings = properties.get("policySettings", {})
+            config["policy_settings"] = {
+                "enabled": policy_settings.get("state", "Enabled") == "Enabled",
+                "mode": policy_settings.get("mode", "Prevention"),
+                "request_body_check": policy_settings.get("requestBodyCheck", True),
+                "max_request_body_size_in_kb": policy_settings.get(
+                    "maxRequestBodySizeInKb", 128
+                ),
+                "file_upload_limit_in_mb": policy_settings.get(
+                    "fileUploadLimitInMb", 100
+                ),
+            }
+
+        # Managed rules (common)
+        managed_rules = properties.get("managedRules", {})
+        if managed_rules.get("managedRuleSets"):
+            rule_sets = []
+            for rule_set in managed_rules.get("managedRuleSets", []):
+                rule_sets.append(
+                    {
+                        "type": rule_set.get("ruleSetType", "OWASP"),
+                        "version": rule_set.get("ruleSetVersion", "3.2"),
+                    }
+                )
+            if is_frontdoor:
+                config["managed_rule"] = rule_sets
+            else:
+                config["managed_rules"] = {"managed_rule_set": rule_sets}
+
+        # Custom rules
+        custom_rules = properties.get("customRules", {}).get("rules", [])
+        if custom_rules:
+            tf_custom_rules = []
+            for rule in custom_rules:
+                tf_rule = {
+                    "name": rule.get("name", "rule"),
+                    "priority": rule.get("priority", 1),
+                    "rule_type": rule.get("ruleType", "MatchRule"),
+                    "action": rule.get("action", "Block"),
+                }
+                # Match conditions
+                match_conditions = rule.get("matchConditions", [])
+                if match_conditions:
+                    tf_matches = []
+                    for match in match_conditions:
+                        tf_matches.append(
+                            {
+                                "match_variable": match.get(
+                                    "matchVariable", "RequestUri"
+                                ),
+                                "operator": match.get("operator", "Contains"),
+                                "match_values": match.get("matchValue", []),
+                            }
+                        )
+                    tf_rule["match_condition"] = tf_matches
+                tf_custom_rules.append(tf_rule)
+            config["custom_rule"] = tf_custom_rules
+
+        logger.debug(f"WAF Policy '{resource_name}' emitted as {terraform_type}")
+
+        return terraform_type, safe_name, config

--- a/src/iac/emitters/terraform/handlers/ml/__init__.py
+++ b/src/iac/emitters/terraform/handlers/ml/__init__.py
@@ -1,0 +1,9 @@
+"""Machine Learning handlers for Terraform emission."""
+
+from .cognitive_services import CognitiveServicesHandler
+from .ml_workspace import MLWorkspaceHandler
+
+__all__ = [
+    "CognitiveServicesHandler",
+    "MLWorkspaceHandler",
+]

--- a/src/iac/emitters/terraform/handlers/ml/cognitive_services.py
+++ b/src/iac/emitters/terraform/handlers/ml/cognitive_services.py
@@ -1,0 +1,60 @@
+"""Cognitive Services handler for Terraform emission.
+
+Handles: Microsoft.CognitiveServices/accounts
+Emits: azurerm_cognitive_account
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class CognitiveServicesHandler(ResourceHandler):
+    """Handler for Azure Cognitive Services.
+
+    Emits:
+        - azurerm_cognitive_account
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.CognitiveServices/accounts",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_cognitive_account",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Cognitive Services account to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Kind (required)
+        kind = properties.get("kind", resource.get("kind", "OpenAI"))
+        config["kind"] = kind
+
+        # SKU (required)
+        sku = properties.get("sku", {})
+        config["sku_name"] = sku.get("name", "S0") if isinstance(sku, dict) else "S0"
+
+        # Custom subdomain
+        custom_subdomain = properties.get("customSubDomainName")
+        if custom_subdomain:
+            config["custom_subdomain_name"] = custom_subdomain
+
+        logger.debug(f"Cognitive Services '{resource_name}' emitted with kind='{kind}'")
+
+        return "azurerm_cognitive_account", safe_name, config

--- a/src/iac/emitters/terraform/handlers/ml/ml_workspace.py
+++ b/src/iac/emitters/terraform/handlers/ml/ml_workspace.py
@@ -1,0 +1,86 @@
+"""ML Workspace handler for Terraform emission.
+
+Handles: Microsoft.MachineLearningServices/workspaces
+Emits: azurerm_machine_learning_workspace
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class MLWorkspaceHandler(ResourceHandler):
+    """Handler for Azure Machine Learning Workspaces.
+
+    Emits:
+        - azurerm_machine_learning_workspace
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.MachineLearningServices/workspaces",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_machine_learning_workspace",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert ML Workspace to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = properties.get("sku", {})
+        config["sku_name"] = (
+            sku.get("name", "Basic") if isinstance(sku, dict) else "Basic"
+        )
+
+        # Identity (required)
+        config["identity"] = {"type": "SystemAssigned"}
+
+        rg_name = self.get_resource_group(resource)
+        sub_id = context.get_effective_subscription_id(resource)
+
+        # Storage account (required)
+        storage_account_id = properties.get("storageAccount")
+        if not storage_account_id:
+            storage_account_id = (
+                f"/subscriptions/{sub_id}/resourceGroups/{rg_name}/"
+                f"providers/Microsoft.Storage/storageAccounts/mlworkspace{resource_name[:8]}"
+            )
+        config["storage_account_id"] = storage_account_id
+
+        # Key Vault (required)
+        key_vault_id = properties.get("keyVault")
+        if not key_vault_id:
+            key_vault_id = (
+                f"/subscriptions/{sub_id}/resourceGroups/{rg_name}/"
+                f"providers/Microsoft.KeyVault/vaults/mlworkspace{resource_name[:8]}"
+            )
+        config["key_vault_id"] = key_vault_id
+
+        # Application Insights (required)
+        app_insights_id = properties.get("applicationInsights")
+        if not app_insights_id:
+            app_insights_id = (
+                f"/subscriptions/{sub_id}/resourceGroups/{rg_name}/"
+                f"providers/Microsoft.Insights/components/mlworkspace{resource_name[:8]}"
+            )
+        config["application_insights_id"] = app_insights_id
+
+        logger.debug(f"ML Workspace '{resource_name}' emitted")
+
+        return "azurerm_machine_learning_workspace", safe_name, config

--- a/src/iac/emitters/terraform/handlers/monitoring/__init__.py
+++ b/src/iac/emitters/terraform/handlers/monitoring/__init__.py
@@ -1,0 +1,21 @@
+"""Monitoring handlers for Terraform emission."""
+
+from .action_group import ActionGroupHandler
+from .app_insights import ApplicationInsightsHandler
+from .dcr import DataCollectionRuleHandler
+from .log_analytics import (
+    LogAnalyticsQueryPackHandler,
+    LogAnalyticsSolutionHandler,
+    LogAnalyticsWorkspaceHandler,
+)
+from .metric_alert import MetricAlertHandler
+
+__all__ = [
+    "ActionGroupHandler",
+    "ApplicationInsightsHandler",
+    "DataCollectionRuleHandler",
+    "LogAnalyticsQueryPackHandler",
+    "LogAnalyticsSolutionHandler",
+    "LogAnalyticsWorkspaceHandler",
+    "MetricAlertHandler",
+]

--- a/src/iac/emitters/terraform/handlers/monitoring/action_group.py
+++ b/src/iac/emitters/terraform/handlers/monitoring/action_group.py
@@ -1,0 +1,59 @@
+"""Action Group handler for Terraform emission.
+
+Handles: Microsoft.Insights/actionGroups
+Emits: azurerm_monitor_action_group
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ActionGroupHandler(ResourceHandler):
+    """Handler for Monitor Action Groups.
+
+    Emits:
+        - azurerm_monitor_action_group
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Insights/actionGroups",
+        "Microsoft.Insights/actiongroups",
+        "microsoft.insights/actiongroups",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_monitor_action_group",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Action Group to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # short_name is required (max 12 characters)
+        short_name = (
+            properties.get("groupShortName")
+            or properties.get("short_name")
+            or resource_name[:12]
+        )
+        config["short_name"] = short_name
+
+        logger.debug(
+            f"Action Group '{resource_name}' emitted with short_name '{short_name}'"
+        )
+
+        return "azurerm_monitor_action_group", safe_name, config

--- a/src/iac/emitters/terraform/handlers/monitoring/app_insights.py
+++ b/src/iac/emitters/terraform/handlers/monitoring/app_insights.py
@@ -1,0 +1,62 @@
+"""Application Insights handler for Terraform emission.
+
+Handles: Microsoft.Insights/components
+Emits: azurerm_application_insights
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ApplicationInsightsHandler(ResourceHandler):
+    """Handler for Application Insights.
+
+    Emits:
+        - azurerm_application_insights
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Insights/components",
+        "microsoft.insights/components",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_application_insights",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Application Insights to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Application type (required)
+        app_type = properties.get("Application_Type", "web")
+        config["application_type"] = app_type
+
+        # Workspace ID (for workspace-based App Insights)
+        workspace_id = properties.get("WorkspaceResourceId")
+        if workspace_id:
+            config["workspace_id"] = workspace_id
+
+        # Retention
+        retention = properties.get("RetentionInDays")
+        if retention:
+            config["retention_in_days"] = retention
+
+        logger.debug(f"Application Insights '{resource_name}' emitted")
+
+        return "azurerm_application_insights", safe_name, config

--- a/src/iac/emitters/terraform/handlers/monitoring/dcr.py
+++ b/src/iac/emitters/terraform/handlers/monitoring/dcr.py
@@ -1,0 +1,159 @@
+"""Data Collection Rule handler for Terraform emission.
+
+Handles: Microsoft.Insights/dataCollectionRules
+Emits: azurerm_monitor_data_collection_rule
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class DataCollectionRuleHandler(ResourceHandler):
+    """Handler for Monitor Data Collection Rules.
+
+    Emits:
+        - azurerm_monitor_data_collection_rule
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Insights/dataCollectionRules",
+        "microsoft.insights/dataCollectionRules",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_monitor_data_collection_rule",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Data Collection Rule to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Extract destinations
+        destinations_prop = properties.get("destinations", {})
+        destinations_config = {}
+
+        # Log Analytics destinations
+        if "logAnalytics" in destinations_prop:
+            log_analytics_list = []
+            for la_dest in destinations_prop["logAnalytics"]:
+                workspace_resource_id = la_dest.get("workspaceResourceId", "")
+                dest_name = la_dest.get("name", "default")
+                if workspace_resource_id:
+                    # Normalize resource ID casing
+                    workspace_resource_id = self._normalize_resource_id(
+                        workspace_resource_id
+                    )
+
+                    # Check if workspace exists in graph
+                    if not self._workspace_exists_in_graph(
+                        workspace_resource_id, context
+                    ):
+                        logger.warning(
+                            f"DCR '{resource_name}' references non-existent "
+                            f"Log Analytics workspace: {workspace_resource_id}. "
+                            f"Skipping this DCR."
+                        )
+                        return None
+
+                    log_analytics_list.append(
+                        {
+                            "workspace_resource_id": workspace_resource_id,
+                            "name": dest_name,
+                        }
+                    )
+
+            if log_analytics_list:
+                destinations_config["log_analytics"] = log_analytics_list
+
+        # Azure Monitor Metrics destinations
+        if "azureMonitorMetrics" in destinations_prop:
+            am_dest = destinations_prop["azureMonitorMetrics"]
+            dest_name = am_dest.get("name", "azureMonitorMetrics-default")
+            destinations_config["azure_monitor_metrics"] = {"name": dest_name}
+
+        # Skip DCRs without destinations
+        if not destinations_config:
+            logger.warning(
+                f"DCR '{resource_name}' has no destinations. "
+                f"Skipping as it cannot be deployed."
+            )
+            return None
+
+        config["destinations"] = destinations_config
+
+        # Extract data flows
+        data_flows_prop = properties.get("dataFlows", [])
+        data_flows_config = []
+
+        for flow in data_flows_prop:
+            flow_config = {
+                "streams": flow.get("streams", ["Microsoft-Perf"]),
+                "destinations": flow.get("destinations", ["default"]),
+            }
+            if "outputStream" in flow:
+                flow_config["output_stream"] = flow["outputStream"]
+            if "transformKql" in flow:
+                flow_config["transform_kql"] = flow["transformKql"]
+            data_flows_config.append(flow_config)
+
+        # Skip DCRs without data flows
+        if not data_flows_config:
+            logger.warning(
+                f"DCR '{resource_name}' has no dataFlows. "
+                f"Skipping as it cannot be deployed."
+            )
+            return None
+
+        config["data_flow"] = data_flows_config
+
+        logger.debug(f"Data Collection Rule '{resource_name}' emitted")
+
+        return "azurerm_monitor_data_collection_rule", safe_name, config
+
+    def _normalize_resource_id(self, resource_id: str) -> str:
+        """Normalize resource ID casing."""
+        # Fix common provider casing issues
+        normalizations = [
+            ("microsoft.operationalinsights", "Microsoft.OperationalInsights"),
+            ("microsoft.insights", "Microsoft.Insights"),
+        ]
+        for old, new in normalizations:
+            if old in resource_id.lower():
+                import re
+
+                resource_id = re.sub(old, new, resource_id, flags=re.IGNORECASE)
+        return resource_id
+
+    def _workspace_exists_in_graph(
+        self,
+        workspace_id: str,
+        context: EmitterContext,
+    ) -> bool:
+        """Check if workspace exists in the graph."""
+        if not context.graph:
+            return True  # Assume exists if no graph reference
+
+        # Extract workspace name from ID
+        workspace_name = self.extract_name_from_id(workspace_id, "workspaces")
+        if workspace_name == "unknown":
+            return True  # Can't validate, assume exists
+
+        workspace_safe = self.sanitize_name(workspace_name)
+        return context.resource_exists(
+            "azurerm_log_analytics_workspace", workspace_safe
+        )

--- a/src/iac/emitters/terraform/handlers/monitoring/log_analytics.py
+++ b/src/iac/emitters/terraform/handlers/monitoring/log_analytics.py
@@ -1,0 +1,140 @@
+"""Log Analytics handlers for Terraform emission.
+
+Handles: Microsoft.OperationalInsights/workspaces, solutions, queryPacks
+Emits: azurerm_log_analytics_workspace, azurerm_log_analytics_solution
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class LogAnalyticsWorkspaceHandler(ResourceHandler):
+    """Handler for Log Analytics Workspaces.
+
+    Emits:
+        - azurerm_log_analytics_workspace
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.OperationalInsights/workspaces",
+        "microsoft.operationalinsights/workspaces",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_log_analytics_workspace",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Log Analytics Workspace to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = properties.get("sku", {})
+        if sku and "name" in sku:
+            config["sku"] = sku["name"]
+
+        # Retention
+        retention = properties.get("retentionInDays")
+        if retention:
+            config["retention_in_days"] = retention
+
+        logger.debug(f"Log Analytics Workspace '{resource_name}' emitted")
+
+        return "azurerm_log_analytics_workspace", safe_name, config
+
+
+@handler
+class LogAnalyticsSolutionHandler(ResourceHandler):
+    """Handler for Log Analytics Solutions.
+
+    Emits:
+        - azurerm_log_analytics_solution
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.OperationsManagement/solutions",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_log_analytics_solution",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Log Analytics Solution to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Solution name
+        config["solution_name"] = resource_name
+
+        # Workspace resource ID
+        workspace_id = properties.get("workspaceResourceId")
+        if workspace_id:
+            config["workspace_resource_id"] = workspace_id
+
+        # Plan
+        plan = properties.get("plan", {})
+        if plan:
+            config["plan"] = {
+                "publisher": plan.get("publisher", "Microsoft"),
+                "product": plan.get("product", "OMSGallery"),
+            }
+
+        logger.debug(f"Log Analytics Solution '{resource_name}' emitted")
+
+        return "azurerm_log_analytics_solution", safe_name, config
+
+
+@handler
+class LogAnalyticsQueryPackHandler(ResourceHandler):
+    """Handler for Log Analytics Query Packs.
+
+    Emits:
+        - azurerm_log_analytics_query_pack
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.OperationalInsights/queryPacks",
+        "microsoft.operationalInsights/querypacks",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_log_analytics_query_pack",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Log Analytics Query Pack to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        config = self.build_base_config(resource)
+
+        logger.debug(f"Log Analytics Query Pack '{resource_name}' emitted")
+
+        return "azurerm_log_analytics_query_pack", safe_name, config

--- a/src/iac/emitters/terraform/handlers/monitoring/metric_alert.py
+++ b/src/iac/emitters/terraform/handlers/monitoring/metric_alert.py
@@ -1,0 +1,81 @@
+"""Metric Alert handler for Terraform emission.
+
+Handles: Microsoft.Insights/metricAlerts
+Emits: azurerm_monitor_metric_alert
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class MetricAlertHandler(ResourceHandler):
+    """Handler for Monitor Metric Alerts.
+
+    Emits:
+        - azurerm_monitor_metric_alert
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Insights/metricAlerts",
+        "Microsoft.Insights/metricalerts",
+        "microsoft.insights/metricalerts",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_monitor_metric_alert",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Metric Alert to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Scopes (required)
+        scopes = properties.get("scopes", [])
+        if scopes:
+            config["scopes"] = scopes
+
+        # Severity
+        severity = properties.get("severity", 3)
+        config["severity"] = severity
+
+        # Enabled
+        enabled = properties.get("enabled", True)
+        config["enabled"] = enabled
+
+        # Criteria
+        criteria = properties.get("criteria", {})
+        if criteria:
+            all_of = criteria.get("allOf", [])
+            if all_of:
+                criteria_config = []
+                for criterion in all_of:
+                    criteria_config.append(
+                        {
+                            "metric_namespace": criterion.get("metricNamespace", ""),
+                            "metric_name": criterion.get("metricName", ""),
+                            "aggregation": criterion.get("timeAggregation", "Average"),
+                            "operator": criterion.get("operator", "GreaterThan"),
+                            "threshold": criterion.get("threshold", 0),
+                        }
+                    )
+                if criteria_config:
+                    config["criteria"] = criteria_config
+
+        logger.debug(f"Metric Alert '{resource_name}' emitted")
+
+        return "azurerm_monitor_metric_alert", safe_name, config

--- a/src/iac/emitters/terraform/handlers/network/__init__.py
+++ b/src/iac/emitters/terraform/handlers/network/__init__.py
@@ -1,0 +1,21 @@
+"""Network handlers for Terraform emission."""
+
+from .bastion import BastionHostHandler
+from .nat_gateway import NATGatewayHandler
+from .nic import NetworkInterfaceHandler
+from .nsg import NetworkSecurityGroupHandler
+from .public_ip import PublicIPHandler
+from .route_table import RouteTableHandler
+from .subnet import SubnetHandler
+from .vnet import VirtualNetworkHandler
+
+__all__ = [
+    "BastionHostHandler",
+    "NATGatewayHandler",
+    "NetworkInterfaceHandler",
+    "NetworkSecurityGroupHandler",
+    "PublicIPHandler",
+    "RouteTableHandler",
+    "SubnetHandler",
+    "VirtualNetworkHandler",
+]

--- a/src/iac/emitters/terraform/handlers/network/bastion.py
+++ b/src/iac/emitters/terraform/handlers/network/bastion.py
@@ -1,0 +1,148 @@
+"""Bastion Host handler for Terraform emission.
+
+Handles: Microsoft.Network/bastionHosts
+Emits: azurerm_bastion_host
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class BastionHostHandler(ResourceHandler):
+    """Handler for Azure Bastion Hosts.
+
+    Emits:
+        - azurerm_bastion_host
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/bastionHosts",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_bastion_host",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Bastion Host to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+        """
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        # Build base configuration
+        config = self.build_base_config(resource)
+
+        ip_configurations = properties.get("ipConfigurations", [])
+        if not ip_configurations:
+            logger.warning(
+                f"Bastion Host '{resource_name}' has no IP configurations in properties. "
+                "Generated Terraform may be invalid."
+            )
+            return None
+
+        # Use first IP configuration
+        ip_config = ip_configurations[0]
+        ip_config_name = ip_config.get("name", "IpConf")
+        ip_props = ip_config.get("properties", {})
+
+        # Extract subnet reference
+        subnet_info = ip_props.get("subnet", {})
+        subnet_id = subnet_info.get("id", "")
+        subnet_reference = self._resolve_subnet_reference(
+            subnet_id, resource_name, context
+        )
+
+        # Extract public IP reference (REQUIRED for Bastion Host)
+        public_ip_info = ip_props.get("publicIPAddress", {})
+        public_ip_id = public_ip_info.get("id", "")
+        public_ip_name = self.extract_name_from_id(public_ip_id, "publicIPAddresses")
+
+        if public_ip_name == "unknown":
+            logger.error(
+                f"Bastion Host '{resource_name}' has no publicIPAddress. "
+                f"Bastion Hosts require a public IP. Skipping."
+            )
+            return None
+
+        public_ip_safe = self.sanitize_name(public_ip_name)
+
+        # Build IP configuration block
+        ip_config_block = {
+            "name": ip_config_name,
+            "subnet_id": subnet_reference or "${azurerm_subnet.unknown_subnet.id}",
+            "public_ip_address_id": f"${{azurerm_public_ip.{public_ip_safe}.id}}",
+        }
+
+        config["ip_configuration"] = ip_config_block
+
+        # Validate public IP exists
+        if not self.validate_resource_reference(
+            "azurerm_public_ip", public_ip_safe, context
+        ):
+            logger.warning(
+                f"Bastion Host '{resource_name}' references public IP '{public_ip_name}' "
+                f"that may not exist in the graph. Azure ID: {public_ip_id}"
+            )
+            context.track_missing_reference(
+                resource_name,
+                "public_ip",
+                public_ip_name,
+                public_ip_id,
+            )
+
+        # Validate subnet reference
+        if subnet_reference and "unknown" in subnet_reference:
+            logger.warning(
+                f"Bastion Host '{resource_name}' has invalid subnet reference. "
+                f"Generated Terraform may be invalid."
+            )
+
+        # Add SKU if present
+        sku = properties.get("sku", {})
+        if sku and "name" in sku:
+            config["sku"] = sku["name"]
+
+        logger.debug(f"Bastion Host '{resource_name}' emitted")
+
+        return "azurerm_bastion_host", safe_name, config
+
+    def _resolve_subnet_reference(
+        self,
+        subnet_id: str,
+        resource_name: str,
+        context: EmitterContext,
+    ) -> Optional[str]:
+        """Resolve a subnet ID to a Terraform reference."""
+        if not subnet_id:
+            return None
+
+        vnet_name = self.extract_name_from_id(subnet_id, "virtualNetworks")
+        subnet_name = self.extract_name_from_id(subnet_id, "subnets")
+
+        if vnet_name == "unknown" or subnet_name == "unknown":
+            return None
+
+        vnet_safe = self.sanitize_name(vnet_name)
+        subnet_safe = self.sanitize_name(subnet_name)
+        scoped_name = f"{vnet_safe}_{subnet_safe}"
+
+        return f"${{azurerm_subnet.{scoped_name}.id}}"

--- a/src/iac/emitters/terraform/handlers/network/nat_gateway.py
+++ b/src/iac/emitters/terraform/handlers/network/nat_gateway.py
@@ -1,0 +1,62 @@
+"""NAT Gateway handler for Terraform emission.
+
+Handles: Microsoft.Network/natGateways
+Emits: azurerm_nat_gateway
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class NATGatewayHandler(ResourceHandler):
+    """Handler for Azure NAT Gateways.
+
+    Emits:
+        - azurerm_nat_gateway
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/natGateways",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_nat_gateway",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure NAT Gateway to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = properties.get("sku", {})
+        if sku and "name" in sku:
+            config["sku_name"] = sku["name"]
+
+        # Idle timeout
+        idle_timeout = properties.get("idleTimeoutInMinutes")
+        if idle_timeout:
+            config["idle_timeout_in_minutes"] = idle_timeout
+
+        # Zones
+        zones = resource.get("zones") or properties.get("zones")
+        if zones:
+            config["zones"] = zones
+
+        logger.debug(f"NAT Gateway '{resource_name}' emitted")
+
+        return "azurerm_nat_gateway", safe_name, config

--- a/src/iac/emitters/terraform/handlers/network/nic.py
+++ b/src/iac/emitters/terraform/handlers/network/nic.py
@@ -1,0 +1,175 @@
+"""Network Interface handler for Terraform emission.
+
+Handles: Microsoft.Network/networkInterfaces
+Emits: azurerm_network_interface
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class NetworkInterfaceHandler(ResourceHandler):
+    """Handler for Azure Network Interfaces.
+
+    Also tracks NIC-NSG associations for deferred emission.
+
+    Emits:
+        - azurerm_network_interface
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/networkInterfaces",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_network_interface",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure NIC to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+        """
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        ip_configurations = properties.get("ipConfigurations", [])
+        if not ip_configurations:
+            logger.error(
+                f"NIC '{resource_name}' has no ip_configurations in properties. "
+                "Skipping this NIC as it cannot be deployed without ip_configuration block."
+            )
+            return None
+
+        # Use first IP configuration
+        ip_config = ip_configurations[0]
+        ip_props = ip_config.get("properties", {})
+        subnet_info = ip_props.get("subnet", {})
+        subnet_id = subnet_info.get("id", "")
+
+        # Resolve VNet-scoped subnet reference
+        subnet_reference = self._resolve_subnet_reference(
+            subnet_id, resource_name, context
+        )
+
+        # Bug #29: Skip NIC if subnet doesn't exist in graph
+        if subnet_reference is None:
+            logger.error(
+                f"Skipping NIC '{resource_name}' - subnet missing from graph. "
+                "NIC cannot be deployed without valid subnet reference."
+            )
+            return None
+
+        private_ip = ip_props.get("privateIPAddress", "")
+        allocation_method = ip_props.get("privateIPAllocationMethod", "Dynamic")
+
+        ip_config_block = {
+            "name": ip_config.get("name", "internal"),
+            "subnet_id": subnet_reference,
+            "private_ip_address_allocation": allocation_method,
+        }
+
+        # Add private IP if static allocation
+        if allocation_method == "Static" and private_ip:
+            ip_config_block["private_ip_address"] = private_ip
+
+        # Build base config
+        config = self.build_base_config(resource)
+        config["ip_configuration"] = ip_config_block
+
+        # Track NSG association if present
+        # NOTE: network_security_group_id field is deprecated
+        # Must use azurerm_network_interface_security_group_association resource
+        nsg_info = properties.get("networkSecurityGroup", {})
+        if nsg_info and "id" in nsg_info:
+            nsg_id = nsg_info["id"]
+            nsg_name = self.extract_name_from_id(nsg_id, "networkSecurityGroups")
+            if nsg_name != "unknown":
+                nsg_safe = self.sanitize_name(nsg_name)
+                context.track_nic_nsg_association(
+                    safe_name, nsg_safe, resource_name, nsg_name
+                )
+                logger.debug(
+                    f"NIC '{resource_name}' will get NSG association: {nsg_name}"
+                )
+
+        # Validate reference (warn if placeholder)
+        if "unknown" in subnet_reference:
+            logger.warning(
+                f"NIC '{resource_name}' has invalid subnet reference. "
+                f"Generated Terraform may be invalid."
+            )
+
+        logger.debug(f"NIC '{resource_name}' emitted")
+
+        return "azurerm_network_interface", safe_name, config
+
+    def _resolve_subnet_reference(
+        self,
+        subnet_id: str,
+        resource_name: str,
+        context: EmitterContext,
+    ) -> Optional[str]:
+        """Resolve a subnet ID to a Terraform reference.
+
+        Args:
+            subnet_id: Azure subnet ID
+            resource_name: Parent resource name for logging
+            context: Emitter context with VNet mappings
+
+        Returns:
+            Terraform reference string or None if subnet not found
+        """
+        if not subnet_id:
+            return None
+
+        # Extract VNet and subnet names
+        vnet_name = self.extract_name_from_id(subnet_id, "virtualNetworks")
+        subnet_name = self.extract_name_from_id(subnet_id, "subnets")
+
+        if vnet_name == "unknown" or subnet_name == "unknown":
+            logger.warning(
+                f"Resource '{resource_name}' has invalid subnet ID: {subnet_id}"
+            )
+            return None
+
+        vnet_safe = self.sanitize_name(vnet_name)
+        subnet_safe = self.sanitize_name(subnet_name)
+        scoped_name = f"{vnet_safe}_{subnet_safe}"
+
+        # Check if subnet exists in context
+        if scoped_name in context.available_subnets:
+            return f"${{azurerm_subnet.{scoped_name}.id}}"
+
+        # Also try VNet ID mapping (Bug #31)
+        if "/virtualNetworks/" in subnet_id and "/subnets/" in subnet_id:
+            vnet_id = subnet_id.split("/subnets/")[0]
+            if vnet_id in context.vnet_id_to_terraform_name:
+                vnet_tf_name = context.vnet_id_to_terraform_name[vnet_id]
+                mapped_scoped_name = f"{vnet_tf_name}_{subnet_safe}"
+                if mapped_scoped_name in context.available_subnets:
+                    return f"${{azurerm_subnet.{mapped_scoped_name}.id}}"
+
+        # Subnet not found - return None to trigger skip
+        logger.warning(
+            f"Resource '{resource_name}' references subnet not in graph: "
+            f"VNet={vnet_name}, Subnet={subnet_name}"
+        )
+        return None

--- a/src/iac/emitters/terraform/handlers/network/nsg.py
+++ b/src/iac/emitters/terraform/handlers/network/nsg.py
@@ -1,0 +1,55 @@
+"""Network Security Group handler for Terraform emission.
+
+Handles: Microsoft.Network/networkSecurityGroups
+Emits: azurerm_network_security_group
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class NetworkSecurityGroupHandler(ResourceHandler):
+    """Handler for Azure Network Security Groups.
+
+    Emits:
+        - azurerm_network_security_group
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/networkSecurityGroups",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_network_security_group",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure NSG to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+        """
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        # Build base configuration - NSGs only need name, location, resource_group_name
+        config = self.build_base_config(resource)
+
+        logger.debug(f"NSG '{resource_name}' emitted")
+
+        return "azurerm_network_security_group", safe_name, config

--- a/src/iac/emitters/terraform/handlers/network/public_ip.py
+++ b/src/iac/emitters/terraform/handlers/network/public_ip.py
@@ -1,0 +1,81 @@
+"""Public IP Address handler for Terraform emission.
+
+Handles: Microsoft.Network/publicIPAddresses
+Emits: azurerm_public_ip
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class PublicIPHandler(ResourceHandler):
+    """Handler for Azure Public IP Addresses.
+
+    Emits:
+        - azurerm_public_ip
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/publicIPAddresses",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_public_ip",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Public IP to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+        """
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        # Build base configuration
+        config = self.build_base_config(resource)
+
+        # Public IP specific properties
+        properties = self.parse_properties(resource)
+
+        # Allocation method (required)
+        allocation_method = resource.get("allocation_method") or properties.get(
+            "publicIPAllocationMethod", "Static"
+        )
+        config["allocation_method"] = allocation_method
+
+        # SKU
+        sku = properties.get("sku", {})
+        if sku and "name" in sku:
+            config["sku"] = sku["name"]
+
+        # IP version
+        ip_version = properties.get("publicIPAddressVersion")
+        if ip_version:
+            config["ip_version"] = ip_version
+
+        # Domain name label
+        dns_settings = properties.get("dnsSettings", {})
+        if dns_settings and "domainNameLabel" in dns_settings:
+            config["domain_name_label"] = dns_settings["domainNameLabel"]
+
+        logger.debug(
+            f"Public IP '{resource_name}' emitted with allocation_method={allocation_method}"
+        )
+
+        return "azurerm_public_ip", safe_name, config

--- a/src/iac/emitters/terraform/handlers/network/route_table.py
+++ b/src/iac/emitters/terraform/handlers/network/route_table.py
@@ -1,0 +1,52 @@
+"""Route Table handler for Terraform emission.
+
+Handles: Microsoft.Network/routeTables
+Emits: azurerm_route_table
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class RouteTableHandler(ResourceHandler):
+    """Handler for Azure Route Tables.
+
+    Emits:
+        - azurerm_route_table
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/routeTables",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_route_table",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Route Table to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # Disable BGP route propagation
+        disable_bgp = properties.get("disableBgpRoutePropagation")
+        if disable_bgp is not None:
+            config["disable_bgp_route_propagation"] = disable_bgp
+
+        logger.debug(f"Route Table '{resource_name}' emitted")
+
+        return "azurerm_route_table", safe_name, config

--- a/src/iac/emitters/terraform/handlers/network/subnet.py
+++ b/src/iac/emitters/terraform/handlers/network/subnet.py
@@ -1,0 +1,150 @@
+"""Standalone Subnet handler for Terraform emission.
+
+Handles: Microsoft.Network/subnets (standalone)
+Emits: azurerm_subnet
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class SubnetHandler(ResourceHandler):
+    """Handler for standalone Azure Subnets.
+
+    Note: Most subnets are emitted inline by VirtualNetworkHandler.
+    This handler handles standalone subnet resources that appear
+    separately in the graph.
+
+    Emits:
+        - azurerm_subnet
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/subnets",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_subnet",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert standalone Azure Subnet to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+        """
+        resource_name = resource.get("name", "unknown")
+        properties = self.parse_properties(resource)
+
+        # Bug #31 Step 3: Use VNet mapping to find terraform name
+        subnet_id = resource.get("original_id") or resource.get("id", "")
+        vnet_name_safe = None
+        vnet_name = "unknown"
+
+        # Try to extract parent VNet ID and look up in mapping
+        if "/virtualNetworks/" in subnet_id and "/subnets/" in subnet_id:
+            # Extract VNet ID portion: everything up to /subnets/
+            vnet_id = subnet_id.split("/subnets/")[0]
+
+            # Look up in mapping (Bug #31 fix for abstracted IDs)
+            if vnet_id in context.vnet_id_to_terraform_name:
+                vnet_name_safe = context.vnet_id_to_terraform_name[vnet_id]
+                vnet_name = self.extract_name_from_id(vnet_id, "virtualNetworks")
+                logger.debug(
+                    f"Bug #31: Found VNet terraform name via mapping: {vnet_id} -> {vnet_name_safe}"
+                )
+
+        # Fallback: Extract VNet name directly from ID
+        if not vnet_name_safe:
+            vnet_name = self.extract_name_from_id(subnet_id, "virtualNetworks")
+            if vnet_name != "unknown":
+                vnet_name_safe = self.sanitize_name(vnet_name)
+
+        # Build VNet-scoped resource name
+        if vnet_name_safe and "/subnets/" in subnet_id:
+            subnet_name_safe = self.sanitize_name(resource_name)
+            safe_name = f"{vnet_name_safe}_{subnet_name_safe}"
+
+            config = {
+                "name": resource_name,
+                "resource_group_name": self.get_resource_group(resource),
+                "virtual_network_name": f"${{azurerm_virtual_network.{vnet_name_safe}.name}}",
+            }
+
+            logger.debug(
+                f"Generated standalone subnet: {safe_name} "
+                f"(VNet: {vnet_name}, Subnet: {resource_name})"
+            )
+        else:
+            logger.warning(
+                f"Standalone subnet '{resource_name}' has no parent VNet in ID: {subnet_id}. "
+                f"Skipping subnet as it cannot be deployed without a VNet."
+            )
+            return None
+
+        # Handle address prefixes with fallback
+        address_prefixes = (
+            [properties.get("addressPrefix")]
+            if properties.get("addressPrefix")
+            else properties.get("addressPrefixes", [])
+        )
+
+        if not address_prefixes or not address_prefixes[0]:
+            logger.warning(f"Subnet '{resource_name}' has no address prefixes")
+            address_prefixes = ["10.0.0.0/24"]
+
+        # Normalize CIDRs
+        normalized_prefixes = []
+        for cidr in address_prefixes:
+            if cidr:
+                normalized = self.normalize_cidr_block(cidr, resource_name)
+                if normalized:
+                    normalized_prefixes.append(normalized)
+                else:
+                    normalized_prefixes.append(cidr)
+
+        config["address_prefixes"] = (
+            normalized_prefixes if normalized_prefixes else address_prefixes
+        )
+
+        # Check for NSG association
+        nsg_info = properties.get("networkSecurityGroup", {})
+        if nsg_info and "id" in nsg_info:
+            nsg_name = self.extract_name_from_id(
+                nsg_info["id"], "networkSecurityGroups"
+            )
+            if nsg_name != "unknown":
+                nsg_safe = self.sanitize_name(nsg_name)
+                context.track_nsg_association(
+                    safe_name, nsg_safe, resource_name, nsg_name
+                )
+                logger.debug(
+                    f"Tracked NSG association for standalone subnet: {resource_name} -> {nsg_name}"
+                )
+
+        # Optional: Service Endpoints
+        service_endpoints = properties.get("serviceEndpoints", [])
+        if service_endpoints:
+            config["service_endpoints"] = [
+                ep["service"] for ep in service_endpoints if "service" in ep
+            ]
+
+        # Track in context
+        context.available_subnets.add(safe_name)
+
+        return "azurerm_subnet", safe_name, config

--- a/src/iac/emitters/terraform/handlers/network/vnet.py
+++ b/src/iac/emitters/terraform/handlers/network/vnet.py
@@ -1,0 +1,252 @@
+"""Virtual Network handler for Terraform emission.
+
+Handles: Microsoft.Network/virtualNetworks
+Emits: azurerm_virtual_network, azurerm_subnet (inline)
+"""
+
+import json
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class VirtualNetworkHandler(ResourceHandler):
+    """Handler for Azure Virtual Networks.
+
+    Also emits inline subnets and tracks NSG associations for
+    deferred emission.
+
+    Emits:
+        - azurerm_virtual_network
+        - azurerm_subnet (inline subnets from VNet properties)
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Network/virtualNetworks",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_virtual_network",
+        "azurerm_subnet",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure VNet to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+        """
+        resource_name = resource.get("name", "unknown")
+        properties = self.parse_properties(resource)
+        safe_name = self.sanitize_name(resource_name)
+        location = self.get_location(resource)
+
+        # Skip VNets with missing resource group
+        rg_name = self.get_resource_group(resource)
+        if not rg_name:
+            logger.warning(
+                f"Skipping VNet '{resource_name}': No resource group found. "
+                f"VNets require a valid resource group for deployment."
+            )
+            return None
+
+        # Extract address space
+        address_prefixes = self._get_address_space(resource, properties, resource_name)
+
+        # Normalize all VNet CIDRs
+        normalized_prefixes = []
+        for cidr in address_prefixes:
+            normalized = self.normalize_cidr_block(cidr, resource_name)
+            if normalized:
+                normalized_prefixes.append(normalized)
+            else:
+                # Keep original if normalization fails
+                normalized_prefixes.append(cidr)
+
+        # Build VNet config
+        config = {
+            "name": resource_name,
+            "location": location,
+            "resource_group_name": rg_name,
+            "address_space": normalized_prefixes,
+        }
+
+        # Add tags
+        tags = resource.get("tags")
+        if tags:
+            parsed_tags = self.parse_tags(tags, resource_name)
+            if parsed_tags:
+                config["tags"] = parsed_tags
+
+        # Bug #31 Step 2: Populate VNet ID -> Terraform name mapping
+        vnet_id = resource.get("id", "")
+        vnet_original_id = resource.get("original_id", "")
+
+        if vnet_id and safe_name:
+            context.vnet_id_to_terraform_name[vnet_id] = safe_name
+            logger.debug(f"Bug #31: Mapped VNet ID {vnet_id} -> {safe_name}")
+
+        if vnet_original_id and vnet_original_id != vnet_id and safe_name:
+            context.vnet_id_to_terraform_name[vnet_original_id] = safe_name
+            logger.debug(
+                f"Bug #31: Mapped VNet original_id {vnet_original_id} -> {safe_name}"
+            )
+
+        # Extract and emit inline subnets
+        self._emit_inline_subnets(resource, properties, safe_name, rg_name, context)
+
+        logger.debug(
+            f"VNet '{resource_name}' emitted with {len(normalized_prefixes)} address spaces"
+        )
+
+        return "azurerm_virtual_network", safe_name, config
+
+    def _get_address_space(
+        self,
+        resource: Dict[str, Any],
+        properties: Dict[str, Any],
+        resource_name: str,
+    ) -> list:
+        """Extract address space from VNet.
+
+        Args:
+            resource: Azure resource dict
+            properties: Parsed properties dict
+            resource_name: Resource name for logging
+
+        Returns:
+            List of address prefixes
+        """
+        # Try properties.addressSpace.addressPrefixes
+        address_space_obj = properties.get("addressSpace", {})
+        prefixes = address_space_obj.get("addressPrefixes", [])
+
+        # Fallback 1: Try top-level addressSpace property
+        if not prefixes and resource.get("addressSpace"):
+            try:
+                addr_space = resource.get("addressSpace")
+                if isinstance(addr_space, str):
+                    prefixes = json.loads(addr_space)
+                    logger.debug(
+                        f"VNet '{resource_name}' using top-level addressSpace: {prefixes}"
+                    )
+                elif isinstance(addr_space, list):
+                    prefixes = addr_space
+            except (json.JSONDecodeError, TypeError) as e:
+                logger.warning(
+                    f"Failed to parse top-level addressSpace for VNet '{resource_name}': {e}"
+                )
+
+        # Fallback 2: Use default
+        if not prefixes:
+            prefixes = ["10.0.0.0/16"]
+            logger.warning(
+                f"VNet '{resource_name}' has no addressSpace, using fallback: {prefixes}"
+            )
+
+        return prefixes
+
+    def _emit_inline_subnets(
+        self,
+        resource: Dict[str, Any],
+        properties: Dict[str, Any],
+        vnet_safe_name: str,
+        rg_name: str,
+        context: EmitterContext,
+    ) -> None:
+        """Emit subnets defined inline in VNet properties.
+
+        Args:
+            resource: Azure resource dict
+            properties: Parsed properties dict
+            vnet_safe_name: Sanitized VNet terraform name
+            rg_name: Resource group name
+            context: Emitter context
+        """
+        resource_name = resource.get("name", "unknown")
+        subnets = properties.get("subnets", [])
+
+        for subnet in subnets:
+            subnet_name = subnet.get("name")
+            if not subnet_name:
+                continue
+
+            subnet_props = subnet.get("properties", {})
+
+            # Handle both addressPrefix (singular) and addressPrefixes (array)
+            address_prefixes = (
+                [subnet_props.get("addressPrefix")]
+                if subnet_props.get("addressPrefix")
+                else subnet_props.get("addressPrefixes", [])
+            )
+
+            if not address_prefixes or not address_prefixes[0]:
+                logger.warning(
+                    f"Subnet '{subnet_name}' in vnet '{resource_name}' has no addressPrefix, skipping"
+                )
+                continue
+
+            address_prefix = address_prefixes[0]
+
+            # Normalize subnet CIDR
+            normalized_cidr = self.normalize_cidr_block(
+                address_prefix, f"{resource_name}/{subnet_name}"
+            )
+            if not normalized_cidr:
+                logger.warning(
+                    f"Subnet '{subnet_name}' has invalid CIDR '{address_prefix}', skipping"
+                )
+                continue
+
+            # Build VNet-scoped subnet resource name
+            subnet_safe_name = self.sanitize_name(subnet_name)
+            scoped_subnet_name = f"{vnet_safe_name}_{subnet_safe_name}"
+
+            # Build subnet resource config
+            subnet_config = {
+                "name": subnet_name,
+                "resource_group_name": rg_name,
+                "virtual_network_name": f"${{azurerm_virtual_network.{vnet_safe_name}.name}}",
+                "address_prefixes": [normalized_cidr],
+            }
+
+            # Check for NSG association
+            nsg_info = subnet_props.get("networkSecurityGroup", {})
+            if nsg_info and "id" in nsg_info:
+                nsg_name = self.extract_name_from_id(
+                    nsg_info["id"], "networkSecurityGroups"
+                )
+                if nsg_name != "unknown":
+                    nsg_safe = self.sanitize_name(nsg_name)
+                    context.track_nsg_association(
+                        scoped_subnet_name, nsg_safe, subnet_name, nsg_name
+                    )
+                    logger.debug(
+                        f"Tracked NSG association for inline subnet: {subnet_name} -> {nsg_name}"
+                    )
+
+            # Add to terraform config
+            context.add_helper_resource(
+                "azurerm_subnet", scoped_subnet_name, subnet_config
+            )
+            context.available_subnets.add(scoped_subnet_name)
+            context.add_resource("azurerm_subnet", scoped_subnet_name)
+
+            logger.debug(
+                f"Emitted inline subnet: {scoped_subnet_name} "
+                f"(VNet: {resource_name}, Subnet: {subnet_name})"
+            )

--- a/src/iac/emitters/terraform/handlers/storage/__init__.py
+++ b/src/iac/emitters/terraform/handlers/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage handlers for Terraform emission."""
+
+from .storage_account import StorageAccountHandler
+
+__all__ = ["StorageAccountHandler"]

--- a/src/iac/emitters/terraform/handlers/storage/storage_account.py
+++ b/src/iac/emitters/terraform/handlers/storage/storage_account.py
@@ -1,0 +1,106 @@
+"""Storage Account handler for Terraform emission.
+
+Handles: Microsoft.Storage/storageAccounts
+Emits: azurerm_storage_account
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class StorageAccountHandler(ResourceHandler):
+    """Handler for Azure Storage Accounts.
+
+    Emits:
+        - azurerm_storage_account
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Storage/storageAccounts",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_storage_account",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Storage Account to Terraform configuration.
+
+        Args:
+            resource: Azure resource dictionary from graph
+            context: Shared emitter context
+
+        Returns:
+            Tuple of (terraform_type, resource_name, config) or None if skipped
+        """
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+
+        # Build base configuration
+        config = self.build_base_config(resource)
+
+        # Storage account specific properties
+        properties = self.parse_properties(resource)
+
+        # Account tier and replication type are required
+        account_tier = resource.get("account_tier") or properties.get(
+            "accountTier", "Standard"
+        )
+        account_replication_type = resource.get(
+            "account_replication_type"
+        ) or properties.get("replicationType", "LRS")
+
+        # Handle SKU extraction from properties
+        sku = properties.get("sku", {})
+        if sku and isinstance(sku, dict):
+            sku_name = sku.get("name", "Standard_LRS")
+            # Parse SKU name (e.g., "Standard_LRS" -> tier="Standard", replication="LRS")
+            if "_" in sku_name:
+                parts = sku_name.split("_")
+                account_tier = parts[0]
+                account_replication_type = "_".join(parts[1:])
+
+        config.update(
+            {
+                "account_tier": account_tier,
+                "account_replication_type": account_replication_type,
+            }
+        )
+
+        # Optional: account_kind (default is StorageV2)
+        kind = properties.get("kind") or resource.get("kind")
+        if kind:
+            config["account_kind"] = kind
+
+        # Optional: access_tier (for BlobStorage and StorageV2)
+        access_tier = properties.get("accessTier") or resource.get("access_tier")
+        if access_tier:
+            config["access_tier"] = access_tier
+
+        # Optional: enable_https_traffic_only
+        https_only = properties.get("supportsHttpsTrafficOnly")
+        if https_only is not None:
+            config["enable_https_traffic_only"] = https_only
+
+        # Optional: min_tls_version
+        tls_version = properties.get("minimumTlsVersion")
+        if tls_version:
+            config["min_tls_version"] = tls_version
+
+        logger.debug(
+            f"Storage Account '{resource_name}' emitted with "
+            f"tier={account_tier}, replication={account_replication_type}"
+        )
+
+        return "azurerm_storage_account", safe_name, config

--- a/src/iac/emitters/terraform/handlers/web/__init__.py
+++ b/src/iac/emitters/terraform/handlers/web/__init__.py
@@ -1,0 +1,11 @@
+"""Web handlers for Terraform emission."""
+
+from .app_service import AppServiceHandler
+from .service_plan import ServicePlanHandler
+from .static_web_app import StaticWebAppHandler
+
+__all__ = [
+    "AppServiceHandler",
+    "ServicePlanHandler",
+    "StaticWebAppHandler",
+]

--- a/src/iac/emitters/terraform/handlers/web/app_service.py
+++ b/src/iac/emitters/terraform/handlers/web/app_service.py
@@ -1,0 +1,99 @@
+"""App Service handler for Terraform emission.
+
+Handles: Microsoft.Web/sites
+Emits: azurerm_linux_web_app, azurerm_windows_web_app
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class AppServiceHandler(ResourceHandler):
+    """Handler for Azure App Services.
+
+    Emits:
+        - azurerm_linux_web_app
+        - azurerm_windows_web_app
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Web/sites",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_linux_web_app",
+        "azurerm_windows_web_app",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure App Service to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        # Determine if Linux or Windows
+        kind = properties.get("kind", resource.get("kind", "")).lower()
+        is_linux = "linux" in kind
+
+        config = self.build_base_config(resource)
+
+        # Build site_config block
+        site_config = {}
+        site_config_props = properties.get("siteConfig", {})
+
+        if is_linux and "linuxFxVersion" in site_config_props:
+            site_config["application_stack"] = {
+                "docker_image": site_config_props["linuxFxVersion"]
+            }
+
+        # Service plan ID
+        service_plan_id = resource.get("app_service_plan_id")
+        if not service_plan_id:
+            # Create a default service plan
+            rg = self.get_resource_group(resource)
+            plan_name = f"{resource_name}-plan"
+            plan_safe_name = self.sanitize_name(plan_name)
+            location = self.get_location(resource)
+
+            context.add_helper_resource(
+                "azurerm_service_plan",
+                plan_safe_name,
+                {
+                    "name": plan_name,
+                    "location": location,
+                    "resource_group_name": rg,
+                    "os_type": "Linux" if is_linux else "Windows",
+                    "sku_name": "B1",
+                },
+            )
+
+            service_plan_id = f"${{azurerm_service_plan.{plan_safe_name}.id}}"
+            logger.debug(
+                f"Created default service plan '{plan_name}' for App Service '{resource_name}'"
+            )
+
+        config.update(
+            {
+                "service_plan_id": service_plan_id,
+                "site_config": site_config if site_config else {},
+            }
+        )
+
+        terraform_type = (
+            "azurerm_linux_web_app" if is_linux else "azurerm_windows_web_app"
+        )
+
+        logger.debug(f"App Service '{resource_name}' emitted as {terraform_type}")
+
+        return terraform_type, safe_name, config

--- a/src/iac/emitters/terraform/handlers/web/service_plan.py
+++ b/src/iac/emitters/terraform/handlers/web/service_plan.py
@@ -1,0 +1,57 @@
+"""Service Plan handler for Terraform emission.
+
+Handles: Microsoft.Web/serverFarms
+Emits: azurerm_service_plan
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class ServicePlanHandler(ResourceHandler):
+    """Handler for Azure App Service Plans.
+
+    Emits:
+        - azurerm_service_plan
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Web/serverFarms",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_service_plan",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Service Plan to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # OS type (required)
+        kind = properties.get("kind", resource.get("kind", "")).lower()
+        os_type = "Linux" if "linux" in kind else "Windows"
+        config["os_type"] = os_type
+
+        # SKU name (required)
+        sku = properties.get("sku", {})
+        sku_name = sku.get("name", "B1") if isinstance(sku, dict) else "B1"
+        config["sku_name"] = sku_name
+
+        logger.debug(f"Service Plan '{resource_name}' emitted with os_type={os_type}")
+
+        return "azurerm_service_plan", safe_name, config

--- a/src/iac/emitters/terraform/handlers/web/static_web_app.py
+++ b/src/iac/emitters/terraform/handlers/web/static_web_app.py
@@ -1,0 +1,53 @@
+"""Static Web App handler for Terraform emission.
+
+Handles: Microsoft.Web/staticSites
+Emits: azurerm_static_web_app
+"""
+
+import logging
+from typing import Any, ClassVar, Dict, Optional, Set, Tuple
+
+from ...base_handler import ResourceHandler
+from ...context import EmitterContext
+from .. import handler
+
+logger = logging.getLogger(__name__)
+
+
+@handler
+class StaticWebAppHandler(ResourceHandler):
+    """Handler for Azure Static Web Apps.
+
+    Emits:
+        - azurerm_static_web_app
+    """
+
+    HANDLED_TYPES: ClassVar[Set[str]] = {
+        "Microsoft.Web/staticSites",
+    }
+
+    TERRAFORM_TYPES: ClassVar[Set[str]] = {
+        "azurerm_static_web_app",
+    }
+
+    def emit(
+        self,
+        resource: Dict[str, Any],
+        context: EmitterContext,
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Convert Azure Static Web App to Terraform configuration."""
+        resource_name = resource.get("name", "unknown")
+        safe_name = self.sanitize_name(resource_name)
+        properties = self.parse_properties(resource)
+
+        config = self.build_base_config(resource)
+
+        # SKU
+        sku = properties.get("sku", {})
+        if sku and "name" in sku:
+            config["sku_tier"] = sku.get("tier", "Free")
+            config["sku_size"] = sku.get("name", "Free")
+
+        logger.debug(f"Static Web App '{resource_name}' emitted")
+
+        return "azurerm_static_web_app", safe_name, config

--- a/src/iac/emitters/terraform/utils/__init__.py
+++ b/src/iac/emitters/terraform/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility functions for Terraform emission."""
+
+__all__ = []


### PR DESCRIPTION
## Summary

This PR refactors the monolithic 5,056-line `terraform_emitter.py` into a modular handler-based architecture:

- **TerraformEmitter (435 lines)**: Thin orchestrator delegating to handlers
- **61 handlers** covering **99 Azure resource types** across 13 categories
- **EmitterContext**: Shared state for handlers (subscription IDs, resource tracking)
- **HandlerRegistry**: Type-based dispatch with `@handler` decorator

### Handler Categories

| Category | Handlers | Azure Types |
|----------|----------|-------------|
| Storage | 1 | StorageAccount |
| Network | 8 | VNet, Subnet, NSG, NIC, PublicIP, Bastion, NAT, RouteTable |
| Compute | 5 | VirtualMachine, ManagedDisk, Snapshot, VMExtensions, SSHKey |
| Identity | 5 | EntraUser, EntraGroup, ServicePrincipal, ManagedIdentity, RoleAssignment |
| KeyVault | 1 | KeyVault |
| Monitoring | 5 | LogAnalytics, AppInsights, ActionGroup, MetricAlert, DCR |
| Database | 4 | SQLServer, SQLDatabase, CosmosDB, PostgreSQL |
| Web | 3 | AppService, ServicePlan, StaticWebApp |
| Container | 4 | AKS, ContainerGroup, ContainerRegistry, ContainerApp |
| ML | 2 | MLWorkspace, CognitiveServices |
| Automation | 2 | AutomationAccount, Runbook |
| DevTest | 3 | DevTestLab, DevTestVM, DevTestSchedule |
| Misc | 11 | ResourceGroup, DNS, EventHub, ServiceBus, Redis, WAF, DataFactory, Databricks, RecoveryVault, AppConfig, SearchService |

### Architecture Benefits

- Each handler independently testable
- New handlers can be added without modifying core emitter
- Clear separation of concerns by resource type
- Maintains existing bug fixes (Bug #31, #57, #67)
- Follows Strategy pattern for extensibility

### Key Files

```
src/iac/emitters/terraform/
├── __init__.py          # Package exports
├── emitter.py           # Main orchestrator (435 lines)
├── context.py           # EmitterContext dataclass
├── base_handler.py      # ResourceHandler ABC
├── handlers/
│   ├── __init__.py      # HandlerRegistry, @handler decorator
│   ├── storage/         # 1 handler
│   ├── network/         # 8 handlers
│   ├── compute/         # 5 handlers
│   ├── identity/        # 5 handlers
│   ├── keyvault/        # 1 handler
│   ├── monitoring/      # 5 handlers
│   ├── database/        # 4 handlers
│   ├── web/             # 3 handlers
│   ├── container/       # 4 handlers
│   ├── ml/              # 2 handlers
│   ├── automation/      # 2 handlers
│   ├── devtest/         # 3 handlers
│   └── misc/            # 11 handlers
└── utils/               # Shared utilities
```

## Test Plan

- [ ] Run existing Terraform emission tests
- [ ] Verify handler registration covers all 99 Azure types
- [ ] Compare output with legacy emitter (golden file comparison)
- [ ] Test cross-tenant emission with identity mapping
- [ ] Verify NSG associations emitted correctly (Bug #57)
- [ ] Verify VNet-scoped subnet naming (Bug #31)

## Migration Notes

This PR adds the new handler architecture alongside the existing `terraform_emitter.py`. A follow-up PR will:
1. Wire the new emitter into the CLI
2. Add golden file tests for regression prevention
3. Remove or deprecate the legacy emitter

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)