### PR TITLE
feat: Add MCP server and visualization export for graph abstractions

### DIFF
--- a/.claude/scenarios/mcp-manager/__init__.py
+++ b/.claude/scenarios/mcp-manager/__init__.py
@@ -16,6 +16,7 @@ Example:
     ...     print(f"{server.name}: {server.enabled}")
 """
 
+from .cli import main
 from .config_manager import backup_config, read_config, restore_config, write_config
 from .mcp_operations import (
     MCPServer,
@@ -24,7 +25,6 @@ from .mcp_operations import (
     list_servers,
     validate_config,
 )
-from .cli import main
 
 __all__ = [
     # Config management

--- a/.claude/scenarios/mcp-manager/cli.py
+++ b/.claude/scenarios/mcp-manager/cli.py
@@ -63,7 +63,7 @@ def format_table(headers: list[str], rows: list[list[str]]) -> str:
     # Build data rows
     data_lines = []
     for row in rows:
-        cells = [f" {str(cell):<{col_widths[i]}} " for i, cell in enumerate(row)]
+        cells = [f" {cell!s:<{col_widths[i]}} " for i, cell in enumerate(row)]
         data_lines.append("|" + "|".join(cells) + "|")
 
     # Assemble table

--- a/.claude/scenarios/mcp-manager/config_manager.py
+++ b/.claude/scenarios/mcp-manager/config_manager.py
@@ -27,7 +27,7 @@ def read_config(config_path: Path) -> dict[str, Any]:
     if not config_path.exists():
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
-    with open(config_path, 'r', encoding='utf-8') as f:
+    with open(config_path, encoding='utf-8') as f:
         return json.load(f)
 
 

--- a/.claude/scenarios/mcp-manager/examples/basic_usage.py
+++ b/.claude/scenarios/mcp-manager/examples/basic_usage.py
@@ -4,20 +4,20 @@
 This script demonstrates programmatic usage of the MCP Manager library.
 """
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from mcp_manager import (
-    read_config,
-    write_config,
     backup_config,
-    list_servers,
-    enable_server,
     disable_server,
+    enable_server,
+    list_servers,
+    read_config,
     validate_config,
+    write_config,
 )
 
 
@@ -73,7 +73,7 @@ def example_enable_server():
         # Validate before writing
         errors = validate_config(new_config)
         if errors:
-            print(f"\n✗ Validation failed:")
+            print("\n✗ Validation failed:")
             for error in errors:
                 print(f"  - {error}")
             return

--- a/.claude/scenarios/mcp-manager/mcp_operations.py
+++ b/.claude/scenarios/mcp-manager/mcp_operations.py
@@ -7,7 +7,6 @@ the input.
 
 import copy
 import json
-import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any

--- a/.claude/scenarios/mcp-manager/tests/test_cli.py
+++ b/.claude/scenarios/mcp-manager/tests/test_cli.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-
 from cli import (
     cmd_add,
     cmd_disable,

--- a/.claude/scenarios/mcp-manager/tests/test_config_manager.py
+++ b/.claude/scenarios/mcp-manager/tests/test_config_manager.py
@@ -1,7 +1,6 @@
 """Tests for config_manager module."""
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/.claude/scenarios/mcp-manager/tests/test_mcp_operations.py
+++ b/.claude/scenarios/mcp-manager/tests/test_mcp_operations.py
@@ -3,7 +3,6 @@
 import copy
 
 import pytest
-
 from mcp_operations import (
     MCPServer,
     add_server,

--- a/.claude/scenarios/mcp_manager/__init__.py
+++ b/.claude/scenarios/mcp_manager/__init__.py
@@ -16,6 +16,7 @@ Example:
     ...     print(f"{server.name}: {server.enabled}")
 """
 
+from .cli import main
 from .config_manager import backup_config, read_config, restore_config, write_config
 from .mcp_operations import (
     MCPServer,
@@ -24,7 +25,6 @@ from .mcp_operations import (
     list_servers,
     validate_config,
 )
-from .cli import main
 
 __all__ = [
     # Config management

--- a/.claude/scenarios/mcp_manager/cli.py
+++ b/.claude/scenarios/mcp_manager/cli.py
@@ -63,7 +63,7 @@ def format_table(headers: list[str], rows: list[list[str]]) -> str:
     # Build data rows
     data_lines = []
     for row in rows:
-        cells = [f" {str(cell):<{col_widths[i]}} " for i, cell in enumerate(row)]
+        cells = [f" {cell!s:<{col_widths[i]}} " for i, cell in enumerate(row)]
         data_lines.append("|" + "|".join(cells) + "|")
 
     # Assemble table

--- a/.claude/scenarios/mcp_manager/config_manager.py
+++ b/.claude/scenarios/mcp_manager/config_manager.py
@@ -27,7 +27,7 @@ def read_config(config_path: Path) -> dict[str, Any]:
     if not config_path.exists():
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
-    with open(config_path, 'r', encoding='utf-8') as f:
+    with open(config_path, encoding='utf-8') as f:
         return json.load(f)
 
 

--- a/.claude/scenarios/mcp_manager/examples/basic_usage.py
+++ b/.claude/scenarios/mcp_manager/examples/basic_usage.py
@@ -4,20 +4,20 @@
 This script demonstrates programmatic usage of the MCP Manager library.
 """
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from mcp_manager import (
-    read_config,
-    write_config,
     backup_config,
-    list_servers,
-    enable_server,
     disable_server,
+    enable_server,
+    list_servers,
+    read_config,
     validate_config,
+    write_config,
 )
 
 
@@ -73,7 +73,7 @@ def example_enable_server():
         # Validate before writing
         errors = validate_config(new_config)
         if errors:
-            print(f"\n✗ Validation failed:")
+            print("\n✗ Validation failed:")
             for error in errors:
                 print(f"  - {error}")
             return

--- a/.claude/scenarios/mcp_manager/mcp_operations.py
+++ b/.claude/scenarios/mcp_manager/mcp_operations.py
@@ -7,7 +7,6 @@ the input.
 
 import copy
 import json
-import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any

--- a/.claude/scenarios/mcp_manager/tests/test_cli.py
+++ b/.claude/scenarios/mcp_manager/tests/test_cli.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-
 from cli import (
     cmd_add,
     cmd_disable,

--- a/.claude/scenarios/mcp_manager/tests/test_config_manager.py
+++ b/.claude/scenarios/mcp_manager/tests/test_config_manager.py
@@ -1,7 +1,6 @@
 """Tests for config_manager module."""
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/.claude/scenarios/mcp_manager/tests/test_mcp_operations.py
+++ b/.claude/scenarios/mcp_manager/tests/test_mcp_operations.py
@@ -3,7 +3,6 @@
 import copy
 
 import pytest
-
 from mcp_operations import (
     MCPServer,
     add_server,

--- a/.claude/skills/context_management/test_full_automation_flow.py
+++ b/.claude/skills/context_management/test_full_automation_flow.py
@@ -67,7 +67,7 @@ def test_automation_at_threshold(token_count, expected_action):
         # Check results
         if "context_automation" in output.get("metadata", {}):
             auto_data = output["metadata"]["context_automation"]
-            print(f"\n✅ Automation Triggered!")
+            print("\n✅ Automation Triggered!")
             print(f"   Actions: {auto_data.get('actions', [])}")
             print(f"   Warnings: {auto_data.get('warnings', [])}")
 
@@ -75,7 +75,7 @@ def test_automation_at_threshold(token_count, expected_action):
                 print(f"   💬 {warning}")
 
         else:
-            print(f"\n⭕ No automation (below threshold)")
+            print("\n⭕ No automation (below threshold)")
 
         return output
 
@@ -126,7 +126,7 @@ def main():
 
         if state.get('last_rehydration'):
             rehydration = state['last_rehydration']
-            print(f"  Last Rehydration:")
+            print("  Last Rehydration:")
             print(f"    - Level: {rehydration.get('level')}")
             print(f"    - Snapshot: {rehydration.get('snapshot')}")
 

--- a/.claude/skills/context_management/test_model_aware_thresholds.py
+++ b/.claude/skills/context_management/test_model_aware_thresholds.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from context_management import TokenMonitor
 
+
 def test_model_aware_thresholds():
     """Test that thresholds adjust based on model size."""
 

--- a/.claude/skills/context_management/test_performance.py
+++ b/.claude/skills/context_management/test_performance.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 """Test performance impact of automation with adaptive frequency."""
 
-import json
 import sys
-import tempfile
 import time
 from pathlib import Path
 
@@ -13,6 +11,7 @@ sys.path.insert(0, str(project_root / ".claude" / "tools" / "amplihack" / "hooks
 sys.path.insert(0, str(project_root / ".claude" / "skills"))
 
 from context_management.automation import ContextAutomation
+
 
 def test_performance():
     """Test performance with adaptive frequency."""
@@ -69,7 +68,7 @@ def test_performance():
 
         elapsed = time.time() - start_time
 
-        print(f"\n📈 Results:")
+        print("\n📈 Results:")
         print(f"   Total tool uses: {num_tools}")
         print(f"   Checks run: {checks_run}")
         print(f"   Skipped: {skips}")

--- a/.claude/skills/context_management/test_with_real_transcript.py
+++ b/.claude/skills/context_management/test_with_real_transcript.py
@@ -103,7 +103,7 @@ def test_with_real_transcript():
         output = hook.process(hook_input)
 
         print("\n✅ Hook Executed Successfully!")
-        print(f"\nHook Output:")
+        print("\nHook Output:")
         print(json.dumps(output, indent=2))
 
         # Check if automation ran
@@ -114,7 +114,7 @@ def test_with_real_transcript():
             print(f"  Warnings: {auto_data.get('warnings', [])}")
 
             # Verify token count was calculated correctly
-            print(f"\n✅ Token calculation working correctly!")
+            print("\n✅ Token calculation working correctly!")
             print(f"   Expected: {expected_tokens:,}")
             print(f"   Threshold: {(expected_tokens/1_000_000)*100:.1f}% = ", end="")
             if expected_tokens < 400000:

--- a/.claude/skills/dynamic-debugger/scripts/monitor_session.py
+++ b/.claude/skills/dynamic-debugger/scripts/monitor_session.py
@@ -7,11 +7,11 @@ Public API:
 """
 
 import json
+import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, Optional
-import sys
+from typing import Any, Dict, Optional
 
 # Public API
 __all__ = ['get_process_info', 'monitor_session']

--- a/.claude/skills/dynamic-debugger/tests/conftest.py
+++ b/.claude/skills/dynamic-debugger/tests/conftest.py
@@ -7,10 +7,9 @@ Following testing pyramid:
 """
 
 import json
-import pytest
-import tempfile
 from pathlib import Path
-from typing import Dict, Any
+
+import pytest
 
 
 @pytest.fixture

--- a/.claude/skills/dynamic-debugger/tests/test_config_generation.py
+++ b/.claude/skills/dynamic-debugger/tests/test_config_generation.py
@@ -5,20 +5,16 @@ Testing pyramid distribution:
 - Tests focus on template loading, variable substitution, and validation
 """
 
-import sys
 import json
-import pytest
+import sys
 from pathlib import Path
-from unittest.mock import patch, mock_open, MagicMock
+
+import pytest
 
 # Add scripts directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from generate_dap_config import (
-    generate_config,
-    validate_config
-)
-
+from generate_dap_config import generate_config, validate_config
 
 # ============================================================================
 # TEMPLATE LOADING TESTS (6 tests)

--- a/.claude/skills/dynamic-debugger/tests/test_integration.py
+++ b/.claude/skills/dynamic-debugger/tests/test_integration.py
@@ -5,19 +5,18 @@ Testing pyramid distribution:
 - Tests focus on multi-component workflows and error recovery
 """
 
-import sys
 import json
-import pytest
 import subprocess
+import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+
+import pytest
 
 # Add scripts directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from detect_language import detect_language, get_debugger_for_language
 from generate_dap_config import generate_config, validate_config
-
 
 # ============================================================================
 # FULL WORKFLOW TESTS (4 tests)
@@ -191,7 +190,6 @@ class TestErrorRecovery:
         # Check if process exists (should not)
         try:
             import os
-            import signal
             os.kill(pid, 0)
             process_exists = True
         except OSError:

--- a/.claude/skills/dynamic-debugger/tests/test_language_detection.py
+++ b/.claude/skills/dynamic-debugger/tests/test_language_detection.py
@@ -6,20 +6,15 @@ Testing pyramid distribution:
 """
 
 import sys
-import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
+
+import pytest
 
 # Add scripts directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from detect_language import (
-    detect_language,
-    get_debugger_for_language,
-    MANIFEST_MAP,
-    EXTENSION_MAP
-)
-
+from detect_language import detect_language, get_debugger_for_language
 
 # ============================================================================
 # MANIFEST FILE DETECTION TESTS (6 tests)
@@ -258,7 +253,6 @@ class TestCLIInterface:
         # Import and run the main section
         with patch('sys.argv', ["detect_language.py", "--path", str(python_project), "--json"]):
             # Re-run the module
-            import json
             from detect_language import detect_language, get_debugger_for_language
 
             lang, conf = detect_language(str(python_project))

--- a/.claude/skills/dynamic-debugger/tests/test_session_monitoring.py
+++ b/.claude/skills/dynamic-debugger/tests/test_session_monitoring.py
@@ -5,26 +5,23 @@ Testing pyramid distribution:
 - Tests focus on resource monitoring with/without psutil, limit checking, and JSON output
 """
 
-import sys
 import json
-import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock, Mock
+import sys
 from datetime import datetime, timedelta
 from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 # Add scripts directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 # Import with error handling for syntax issues in the original script
 try:
-    from monitor_session import (
-        get_process_info,
-        monitor_session,
-        HAS_PSUTIL
-    )
     # Import limits safely
     import monitor_session as ms
+    from monitor_session import HAS_PSUTIL, get_process_info, monitor_session
     MAX_MEMORY_MB = getattr(ms, 'MAX_MEMORY_MB', 4096)
     SESSION_TIMEOUT_MIN = getattr(ms, 'SESSION_TIMEOUT_MIN', 30)
 except SyntaxError:

--- a/examples/performance_optimizations_demo.py
+++ b/examples/performance_optimizations_demo.py
@@ -13,7 +13,6 @@ import asyncio
 import json
 import logging
 import os
-from datetime import datetime
 
 from src.services.scale_performance import (
     AdaptiveBatchSizer,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ dependencies = [
     # Pydantic for configuration validation
     "pydantic>=2.0",
     "python-pptx>=1.0.2",
+    # Graph visualization export (Issue #508)
+    "pydot>=3.0.0",
 ]
 
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -23,6 +23,7 @@ from src.commands.auth import app_registration as app_registration_cmd
 
 # Import modular commands for CLI registration (Issue #482)
 from src.commands.deploy import deploy_command
+from src.commands.export_abstraction import export_abstraction_command
 from src.commands.list_deployments import list_deployments
 from src.commands.spa import spa_start as spa_start_command
 from src.commands.spa import spa_stop as spa_stop_command
@@ -1086,6 +1087,9 @@ cli.add_command(deploy_command, "deploy")
 cli.add_command(undeploy, "undeploy")
 cli.add_command(list_deployments, "list-deployments")
 cli.add_command(validate_deployment_command, "validate-deployment")
+
+# Register export-abstraction command (Issue #508)
+cli.add_command(export_abstraction_command, "export-abstraction")
 
 
 @cli.command()

--- a/spa/screenshots/ui-tutorial/annotate_screenshots.py
+++ b/spa/screenshots/ui-tutorial/annotate_screenshots.py
@@ -4,10 +4,11 @@ Professional screenshot annotation script for Scale Operations UI Tutorial.
 Creates annotated versions of screenshots with arrows, boxes, and labels.
 """
 
-from PIL import Image, ImageDraw, ImageFont
 import os
 from pathlib import Path
-from typing import List, Tuple, Optional
+from typing import List, Tuple
+
+from PIL import Image, ImageDraw, ImageFont
 
 
 class AnnotationStyle:

--- a/src/commands/export_abstraction.py
+++ b/src/commands/export_abstraction.py
@@ -1,0 +1,135 @@
+"""Export Abstraction command.
+
+Philosophy:
+- Single responsibility: CLI interface only (thin wrapper over service)
+- Ruthless simplicity: Delegate to GraphExportService
+- Zero-BS implementation: Clear error messages, no stubs
+
+Exports graph abstractions to visualization formats:
+- GraphML (Gephi, Cytoscape, yEd)
+- JSON (D3.js, custom visualization tools)
+- DOT (Graphviz rendering)
+
+Usage:
+    atg export-abstraction --tenant-id abc-123 --output graph.graphml
+    atg export-abstraction --output graph.json --format json
+    atg export-abstraction --output graph.dot --format dot --no-relationships
+
+Issue #508: MCP Server and Visualization Export Integration
+"""
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from src.commands.base import async_command, get_neo4j_config_from_env, get_tenant_id
+from src.config_manager import LoggingConfig, Neo4jConfig, setup_logging
+from src.services.graph_export_service import GraphExportService
+from src.utils.session_manager import Neo4jSessionManager
+
+
+@click.command("export-abstraction")
+@click.option(
+    "--tenant-id",
+    required=False,
+    help="Azure tenant ID (defaults to AZURE_TENANT_ID from .env)",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=click.Path(),
+    help="Output file path (e.g., abstraction.graphml)",
+)
+@click.option(
+    "--format",
+    type=click.Choice(["graphml", "json", "dot"], case_sensitive=False),
+    default="graphml",
+    help="Export format (default: graphml)",
+)
+@click.option(
+    "--no-relationships",
+    is_flag=True,
+    help="Export nodes only (no edges)",
+)
+@async_command
+async def export_abstraction_command(
+    tenant_id: Optional[str],
+    output: str,
+    format: str,
+    no_relationships: bool,
+) -> None:
+    """Export graph abstraction to visualization format.
+
+    Supported formats:
+      - graphml: For Gephi, Cytoscape, yEd
+      - json: For D3.js, custom visualization tools
+      - dot: For Graphviz rendering
+
+    Example:
+        atg export-abstraction --tenant-id abc-123 --output graph.graphml
+        atg export-abstraction --output graph.json --format json
+        atg export-abstraction --output graph.dot --format dot --no-relationships
+    """
+    # Setup logging
+    logging_config = LoggingConfig(level="INFO")
+    setup_logging(logging_config)
+
+    # Get tenant ID
+    tenant_id_resolved = get_tenant_id(tenant_id)
+
+    # Get Neo4j connection
+    neo4j_uri, neo4j_user, neo4j_password = get_neo4j_config_from_env()
+
+    click.echo(f"Exporting abstraction for tenant: {tenant_id_resolved}")
+    click.echo(f"Format: {format}")
+    click.echo(f"Output: {output}")
+
+    try:
+        # Connect to Neo4j
+        neo4j_config = Neo4jConfig(
+            uri=neo4j_uri, user=neo4j_user, password=neo4j_password
+        )
+        session_manager = Neo4jSessionManager(neo4j_config)
+        session_manager.connect()
+
+        # Export abstraction
+        service = GraphExportService(session_manager)
+        result = service.export_abstraction(
+            tenant_id=tenant_id_resolved,
+            output_path=Path(output),
+            format=format,
+            include_relationships=not no_relationships,
+        )
+
+        # Display results
+        if result["success"]:
+            click.echo("\nExport complete!")
+            click.echo(f"  Nodes: {result['node_count']}")
+            click.echo(f"  Edges: {result['edge_count']}")
+            click.echo(f"  File: {result['output_path']}")
+
+            # Format-specific usage tips
+            if format == "graphml":
+                click.echo("\nOpen in Gephi:")
+                click.echo(f"  File → Open → {result['output_path']}")
+            elif format == "json":
+                click.echo("\nUse with D3.js:")
+                click.echo(f"  d3.json('{result['output_path']}').then(data => ...)")
+            elif format == "dot":
+                click.echo("\nRender with Graphviz:")
+                click.echo(f"  dot -Tpng {result['output_path']} -o graph.png")
+        else:
+            click.echo("Export failed", err=True)
+            sys.exit(1)
+
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"Unexpected error: {e}", err=True)
+        sys.exit(1)
+
+
+__all__ = ["export_abstraction_command"]

--- a/src/services/graph_abstraction_mcp_server.py
+++ b/src/services/graph_abstraction_mcp_server.py
@@ -1,0 +1,334 @@
+"""MCP Server exposing graph abstraction operations to LLM agents.
+
+Philosophy:
+- Single responsibility: MCP interface layer only (no business logic)
+- Ruthless simplicity: 4 tools, stateless, delegate to Neo4j session
+- Zero-BS implementation: Every method works, no stubs or TODOs
+
+Public API (the "studs"):
+    GraphAbstractionMCPServer: Main MCP server class
+    run: Server entry point
+
+Dependencies:
+- mcp>=1.9.4 (Model Context Protocol SDK)
+- src.utils.session_manager.Neo4jSessionManager (Neo4j connection)
+
+Usage:
+    ```python
+    from src.utils.session_manager import Neo4jSessionManager
+    from src.services.graph_abstraction_mcp_server import GraphAbstractionMCPServer
+
+    session_manager = Neo4jSessionManager(neo4j_config)
+    session_manager.connect()
+
+    server = GraphAbstractionMCPServer(session_manager)
+    await server.run()
+    ```
+
+Provides 4 tools:
+1. list_tenant_abstractions - List all abstractions for a tenant
+2. get_abstraction_metadata - Get metadata for specific abstraction
+3. get_abstraction_quality - Get quality metrics for abstraction
+4. compare_abstractions - Compare two abstractions side by side
+
+Issue #508: MCP Server and Visualization Export Integration
+"""
+
+import statistics
+from typing import Any, Dict, List
+
+import structlog
+from mcp.server import Server
+from mcp.types import TextContent, Tool
+
+from src.utils.session_manager import Neo4jSessionManager
+
+logger = structlog.get_logger(__name__)
+
+
+class GraphAbstractionMCPServer:
+    """MCP Server for graph abstraction operations.
+
+    Exposes graph abstraction data and operations via Model Context Protocol.
+    Designed to be consumed by LLM agents (Claude Desktop, Zed, etc.).
+    """
+
+    def __init__(self, session_manager: Neo4jSessionManager) -> None:
+        """Initialize MCP server.
+
+        Args:
+            session_manager: Neo4j session manager for database operations
+        """
+        self.session_manager = session_manager
+        self.server = Server("graph-abstraction-server")
+        self._register_tools()
+
+    def _register_tools(self) -> None:
+        """Register MCP tools."""
+
+        @self.server.list_tools()
+        async def list_tools() -> List[Tool]:
+            """List available MCP tools."""
+            return [
+                Tool(
+                    name="list_tenant_abstractions",
+                    description="List all graph abstractions for a tenant",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "tenant_id": {
+                                "type": "string",
+                                "description": "Azure tenant ID",
+                            }
+                        },
+                        "required": ["tenant_id"],
+                    },
+                ),
+                Tool(
+                    name="get_abstraction_metadata",
+                    description="Get metadata for a specific abstraction",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "tenant_id": {
+                                "type": "string",
+                                "description": "Azure tenant ID",
+                            }
+                        },
+                        "required": ["tenant_id"],
+                    },
+                ),
+                Tool(
+                    name="get_abstraction_quality",
+                    description="Get quality metrics for an abstraction",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "tenant_id": {
+                                "type": "string",
+                                "description": "Azure tenant ID",
+                            }
+                        },
+                        "required": ["tenant_id"],
+                    },
+                ),
+                Tool(
+                    name="compare_abstractions",
+                    description="Compare quality metrics between two abstractions",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "tenant_id_1": {
+                                "type": "string",
+                                "description": "First tenant ID",
+                            },
+                            "tenant_id_2": {
+                                "type": "string",
+                                "description": "Second tenant ID",
+                            },
+                        },
+                        "required": ["tenant_id_1", "tenant_id_2"],
+                    },
+                ),
+            ]
+
+        @self.server.call_tool()
+        async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+            """Handle tool calls."""
+            if name == "list_tenant_abstractions":
+                return await self._list_tenant_abstractions(arguments)
+            elif name == "get_abstraction_metadata":
+                return await self._get_abstraction_metadata(arguments)
+            elif name == "get_abstraction_quality":
+                return await self._get_abstraction_quality(arguments)
+            elif name == "compare_abstractions":
+                return await self._compare_abstractions(arguments)
+            else:
+                raise ValueError(f"Unknown tool: {name}")
+
+    async def _list_tenant_abstractions(
+        self, arguments: Dict[str, Any]
+    ) -> List[TextContent]:
+        """List all abstractions for a tenant."""
+        tenant_id = arguments["tenant_id"]
+
+        with self.session_manager.session() as session:
+            result = session.run(
+                """
+                MATCH (sample:Resource)-[:SAMPLE_OF]->(source:Resource)
+                WHERE source.tenant_id = $tenant_id
+                RETURN source.tenant_id as tenant_id,
+                       count(DISTINCT sample) as sample_count,
+                       count(DISTINCT source) as source_count,
+                       collect(DISTINCT source.type)[0..10] as sample_types
+                """,
+                tenant_id=tenant_id,
+            )
+
+            data = result.single()
+            if not data:
+                return [
+                    TextContent(
+                        type="text",
+                        text=f"No abstractions found for tenant {tenant_id}",
+                    )
+                ]
+
+            return [
+                TextContent(
+                    type="text",
+                    text=f"""Abstraction for tenant {tenant_id}:
+- Sample size: {data["sample_count"]} nodes
+- Source size: {data["source_count"]} nodes
+- Sample ratio: {data["sample_count"] / max(1, data["source_count"]):.2%}
+- Sample types: {", ".join(data["sample_types"][:5])}
+""",
+                )
+            ]
+
+    async def _get_abstraction_metadata(
+        self, arguments: Dict[str, Any]
+    ) -> List[TextContent]:
+        """Get detailed metadata for abstraction."""
+        tenant_id = arguments["tenant_id"]
+
+        with self.session_manager.session() as session:
+            # Get type distribution
+            result = session.run(
+                """
+                MATCH (sample:Resource)-[:SAMPLE_OF]->(source:Resource)
+                WHERE source.tenant_id = $tenant_id
+                RETURN source.type as type, count(sample) as count
+                ORDER BY count DESC
+                """,
+                tenant_id=tenant_id,
+            )
+
+            type_dist = {record["type"]: record["count"] for record in result.data()}
+
+            if not type_dist:
+                return [
+                    TextContent(
+                        type="text",
+                        text=f"No abstraction found for tenant {tenant_id}",
+                    )
+                ]
+
+            # Format as readable text
+            dist_text = "\n".join(
+                [f"  {type_name}: {count}" for type_name, count in type_dist.items()]
+            )
+
+            return [
+                TextContent(
+                    type="text",
+                    text=f"""Abstraction metadata for {tenant_id}:
+
+Type distribution:
+{dist_text}
+
+Total types: {len(type_dist)}
+Total samples: {sum(type_dist.values())}
+""",
+                )
+            ]
+
+    async def _get_abstraction_quality(
+        self, arguments: Dict[str, Any]
+    ) -> List[TextContent]:
+        """Get quality metrics for abstraction."""
+        tenant_id = arguments["tenant_id"]
+
+        with self.session_manager.session() as session:
+            # Calculate quality metrics
+            result = session.run(
+                """
+                MATCH (sample:Resource)-[:SAMPLE_OF]->(source:Resource)
+                WHERE source.tenant_id = $tenant_id
+                WITH source.type as type,
+                     count(sample) as sample_count,
+                     count(source) as source_count
+                RETURN type,
+                       sample_count,
+                       source_count,
+                       toFloat(sample_count) / source_count as ratio
+                ORDER BY type
+                """,
+                tenant_id=tenant_id,
+            )
+
+            records = result.data()
+            if not records:
+                return [
+                    TextContent(
+                        type="text",
+                        text=f"No abstraction found for tenant {tenant_id}",
+                    )
+                ]
+
+            # Calculate distribution preservation quality (coefficient of variation)
+            ratios = [r["ratio"] for r in records]
+            avg_ratio = statistics.mean(ratios)
+            std_ratio = statistics.stdev(ratios) if len(ratios) > 1 else 0
+            cv = std_ratio / avg_ratio if avg_ratio > 0 else 0
+
+            # Format metrics
+            metrics_text = "\n".join(
+                [
+                    f"  {r['type']}: {r['sample_count']}/{r['source_count']} ({r['ratio']:.1%})"
+                    for r in records[:10]  # Top 10 types
+                ]
+            )
+
+            return [
+                TextContent(
+                    type="text",
+                    text=f"""Abstraction quality for {tenant_id}:
+
+Average sampling ratio: {avg_ratio:.2%}
+Ratio std deviation: {std_ratio:.3f}
+Coefficient of variation: {cv:.3f}
+(Lower CV = better distribution preservation)
+
+Sample ratios by type:
+{metrics_text}
+""",
+                )
+            ]
+
+    async def _compare_abstractions(
+        self, arguments: Dict[str, Any]
+    ) -> List[TextContent]:
+        """Compare two abstractions."""
+        tenant_id_1 = arguments["tenant_id_1"]
+        tenant_id_2 = arguments["tenant_id_2"]
+
+        # Get quality metrics for both
+        quality_1 = await self._get_abstraction_quality({"tenant_id": tenant_id_1})
+        quality_2 = await self._get_abstraction_quality({"tenant_id": tenant_id_2})
+
+        return [
+            TextContent(
+                type="text",
+                text=f"""Comparison of abstractions:
+
+=== Tenant 1: {tenant_id_1} ===
+{quality_1[0].text}
+
+=== Tenant 2: {tenant_id_2} ===
+{quality_2[0].text}
+""",
+            )
+        ]
+
+    async def run(self) -> None:
+        """Run the MCP server."""
+        from mcp.server.stdio import stdio_server
+
+        async with stdio_server() as (read_stream, write_stream):
+            await self.server.run(
+                read_stream, write_stream, self.server.create_initialization_options()
+            )
+
+
+__all__ = ["GraphAbstractionMCPServer"]

--- a/src/services/graph_export_service.py
+++ b/src/services/graph_export_service.py
@@ -1,0 +1,227 @@
+"""Graph Export Service for visualization-friendly formats.
+
+Philosophy:
+- Single responsibility: Data transformation only (no business logic)
+- Ruthless simplicity: 3 export formats, NetworkX intermediary
+- Zero-BS implementation: Every method works, validates output
+
+Public API (the "studs"):
+    GraphExportService: Main export service class
+    export_abstraction: Export to GraphML/JSON/DOT
+
+Dependencies:
+- networkx>=3.0 (graph data structure)
+- pydot>=3.0.0 (DOT format writer)
+- src.utils.session_manager.Neo4jSessionManager (Neo4j connection)
+
+Supports:
+- GraphML: For Gephi, Cytoscape, yEd
+- JSON: For D3.js, custom visualization tools
+- DOT: For Graphviz rendering
+
+Usage:
+    ```python
+    from src.services.graph_export_service import GraphExportService
+    from src.utils.session_manager import Neo4jSessionManager
+
+    session_manager = Neo4jSessionManager(neo4j_config)
+    service = GraphExportService(session_manager)
+
+    result = service.export_abstraction(
+        tenant_id="abc-123",
+        output_path=Path("graph.graphml"),
+        format="graphml"
+    )
+    ```
+
+Issue #508: MCP Server and Visualization Export Integration
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import networkx as nx
+import structlog
+
+from src.utils.session_manager import Neo4jSessionManager
+
+logger = structlog.get_logger(__name__)
+
+
+class GraphExportService:
+    """Service for exporting graph abstractions to various formats.
+
+    Exports graph abstractions to visualization-friendly formats:
+    - GraphML (Gephi, Cytoscape)
+    - JSON (D3.js, custom tools)
+    - DOT (Graphviz)
+    """
+
+    def __init__(self, session_manager: Neo4jSessionManager) -> None:
+        """Initialize export service.
+
+        Args:
+            session_manager: Neo4j session manager
+        """
+        self.session_manager = session_manager
+
+    def export_abstraction(
+        self,
+        tenant_id: str,
+        output_path: Path,
+        format: str = "graphml",
+        include_relationships: bool = True,
+    ) -> Dict[str, Any]:
+        """Export graph abstraction to file.
+
+        Args:
+            tenant_id: Tenant to export
+            output_path: Output file path
+            format: Export format (graphml, json, dot)
+            include_relationships: Include edges between resources
+
+        Returns:
+            Dictionary with export metadata:
+                - success: bool
+                - format: str
+                - output_path: str
+                - node_count: int
+                - edge_count: int
+
+        Raises:
+            ValueError: If format is unsupported or tenant not found
+        """
+        format = format.lower()
+        if format not in ("graphml", "json", "dot"):
+            raise ValueError(f"Unsupported format: {format}. Use graphml, json, or dot")
+
+        # Build NetworkX graph from Neo4j
+        graph = self._build_networkx_graph(tenant_id, include_relationships)
+
+        if graph.number_of_nodes() == 0:
+            raise ValueError(f"No abstraction found for tenant {tenant_id}")
+
+        # Export to format
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if format == "graphml":
+            nx.write_graphml(graph, str(output_path))
+        elif format == "json":
+            self._export_to_json(graph, output_path)
+        elif format == "dot":
+            nx.drawing.nx_pydot.write_dot(graph, str(output_path))
+
+        logger.info(
+            f"Exported {graph.number_of_nodes()} nodes to {format}",
+            tenant_id=tenant_id,
+            format=format,
+            output_path=str(output_path),
+        )
+
+        return {
+            "success": True,
+            "format": format,
+            "output_path": str(output_path),
+            "node_count": graph.number_of_nodes(),
+            "edge_count": graph.number_of_edges(),
+        }
+
+    def _build_networkx_graph(
+        self, tenant_id: str, include_relationships: bool
+    ) -> nx.DiGraph:
+        """Build NetworkX graph from Neo4j abstraction.
+
+        Args:
+            tenant_id: Tenant to export
+            include_relationships: Include edges between resources
+
+        Returns:
+            NetworkX directed graph
+        """
+        graph = nx.DiGraph()
+
+        with self.session_manager.session() as session:
+            # Add nodes (sampled resources)
+            node_result = session.run(
+                """
+                MATCH (sample:Resource)-[:SAMPLE_OF]->(source:Resource)
+                WHERE source.tenant_id = $tenant_id
+                RETURN source.id as id,
+                       source.name as name,
+                       source.type as type,
+                       source.location as location,
+                       source.tenant_id as tenant_id
+                """,
+                tenant_id=tenant_id,
+            )
+
+            for record in node_result:
+                # Use 'label' instead of 'name' to avoid pydot conflict
+                # (pydot.Node uses 'name' as constructor parameter)
+                graph.add_node(
+                    record["id"],
+                    label=record["name"] or "",
+                    type=record["type"] or "",
+                    location=record["location"] or "",
+                    tenant_id=record["tenant_id"] or "",
+                )
+
+            # Add edges (relationships between sampled resources)
+            if include_relationships:
+                edge_result = session.run(
+                    """
+                    MATCH (sample1:Resource)-[:SAMPLE_OF]->(source1:Resource)
+                    MATCH (sample2:Resource)-[:SAMPLE_OF]->(source2:Resource)
+                    MATCH (source1)-[r]->(source2)
+                    WHERE source1.tenant_id = $tenant_id
+                      AND source2.tenant_id = $tenant_id
+                    RETURN source1.id as source_id,
+                           source2.id as target_id,
+                           type(r) as rel_type
+                    """,
+                    tenant_id=tenant_id,
+                )
+
+                for record in edge_result:
+                    graph.add_edge(
+                        record["source_id"],
+                        record["target_id"],
+                        relationship=record["rel_type"],
+                    )
+
+        return graph
+
+    def _export_to_json(self, graph: nx.DiGraph, output_path: Path) -> None:
+        """Export graph to D3.js-compatible JSON format.
+
+        Format:
+        {
+            "nodes": [{"id": "...", "name": "...", "type": "..."}],
+            "links": [{"source": "...", "target": "...", "relationship": "..."}]
+        }
+
+        Args:
+            graph: NetworkX graph to export
+            output_path: Output file path
+        """
+        nodes = [{"id": node_id, **graph.nodes[node_id]} for node_id in graph.nodes()]
+
+        links = [
+            {"source": source, "target": target, **graph.edges[source, target]}
+            for source, target in graph.edges()
+        ]
+
+        output = {
+            "nodes": nodes,
+            "links": links,
+            "metadata": {
+                "node_count": len(nodes),
+                "edge_count": len(links),
+            },
+        }
+
+        output_path.write_text(json.dumps(output, indent=2))
+
+
+__all__ = ["GraphExportService"]

--- a/src/services/scale_down_service.py
+++ b/src/services/scale_down_service.py
@@ -18,4 +18,4 @@ from src.services.scale_down.quality_metrics import QualityMetrics
 # Backward compatibility alias
 ScaleDownService = ScaleDownOrchestrator
 
-__all__ = ["ScaleDownService", "QualityMetrics", "ScaleDownOrchestrator"]
+__all__ = ["QualityMetrics", "ScaleDownOrchestrator", "ScaleDownService"]

--- a/tests/commands/test_export_abstraction.py
+++ b/tests/commands/test_export_abstraction.py
@@ -1,0 +1,299 @@
+"""Tests for export-abstraction CLI command (Issue #508).
+
+Test Coverage:
+- Help text
+- Successful exports (GraphML, JSON, DOT)
+- Error handling (invalid tenant, missing files)
+- Output formatting
+- Flag handling (--no-relationships)
+
+Target: 70% coverage
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from src.commands.export_abstraction import export_abstraction_command
+
+
+class TestExportAbstractionCommand:
+    """Test suite for export-abstraction CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_export_abstraction_help(self, runner):
+        """Test help text displays correctly."""
+        result = runner.invoke(export_abstraction_command, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Export graph abstraction" in result.output
+        assert "graphml" in result.output
+        assert "json" in result.output
+        assert "dot" in result.output
+        assert "--tenant-id" in result.output
+        assert "--output" in result.output
+        assert "--format" in result.output
+
+    @patch("src.commands.export_abstraction.GraphExportService")
+    @patch("src.commands.export_abstraction.Neo4jSessionManager")
+    @patch("src.commands.export_abstraction.get_neo4j_config_from_env")
+    @patch("src.commands.export_abstraction.get_tenant_id")
+    def test_export_abstraction_graphml_success(
+        self,
+        mock_get_tenant_id,
+        mock_get_neo4j_config,
+        mock_session_manager_class,
+        mock_export_service_class,
+        runner,
+    ):
+        """Test successful GraphML export."""
+        # Mock configuration
+        mock_get_tenant_id.return_value = "test-tenant"
+        mock_get_neo4j_config.return_value = (
+            "bolt://localhost:7687",
+            "neo4j",
+            "password",
+        )
+
+        # Mock service
+        service_instance = Mock()
+        service_instance.export_abstraction.return_value = {
+            "success": True,
+            "format": "graphml",
+            "output_path": "test.graphml",
+            "node_count": 100,
+            "edge_count": 150,
+        }
+        mock_export_service_class.return_value = service_instance
+
+        # Run command
+        result = runner.invoke(
+            export_abstraction_command,
+            [
+                "--tenant-id",
+                "test-tenant",
+                "--output",
+                "test.graphml",
+                "--format",
+                "graphml",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Export complete" in result.output
+        assert "100" in result.output  # node count
+        assert "150" in result.output  # edge count
+        assert "Gephi" in result.output  # usage tip
+
+    @patch("src.commands.export_abstraction.GraphExportService")
+    @patch("src.commands.export_abstraction.Neo4jSessionManager")
+    @patch("src.commands.export_abstraction.get_neo4j_config_from_env")
+    @patch("src.commands.export_abstraction.get_tenant_id")
+    def test_export_abstraction_json_success(
+        self,
+        mock_get_tenant_id,
+        mock_get_neo4j_config,
+        mock_session_manager_class,
+        mock_export_service_class,
+        runner,
+    ):
+        """Test successful JSON export with D3.js tip."""
+        mock_get_tenant_id.return_value = "test-tenant"
+        mock_get_neo4j_config.return_value = (
+            "bolt://localhost:7687",
+            "neo4j",
+            "password",
+        )
+
+        service_instance = Mock()
+        service_instance.export_abstraction.return_value = {
+            "success": True,
+            "format": "json",
+            "output_path": "test.json",
+            "node_count": 50,
+            "edge_count": 75,
+        }
+        mock_export_service_class.return_value = service_instance
+
+        result = runner.invoke(
+            export_abstraction_command,
+            ["--tenant-id", "test-tenant", "--output", "test.json", "--format", "json"],
+        )
+
+        assert result.exit_code == 0
+        assert "Export complete" in result.output
+        assert "D3.js" in result.output  # usage tip
+
+    @patch("src.commands.export_abstraction.GraphExportService")
+    @patch("src.commands.export_abstraction.Neo4jSessionManager")
+    @patch("src.commands.export_abstraction.get_neo4j_config_from_env")
+    @patch("src.commands.export_abstraction.get_tenant_id")
+    def test_export_abstraction_dot_success(
+        self,
+        mock_get_tenant_id,
+        mock_get_neo4j_config,
+        mock_session_manager_class,
+        mock_export_service_class,
+        runner,
+    ):
+        """Test successful DOT export with Graphviz tip."""
+        mock_get_tenant_id.return_value = "test-tenant"
+        mock_get_neo4j_config.return_value = (
+            "bolt://localhost:7687",
+            "neo4j",
+            "password",
+        )
+
+        service_instance = Mock()
+        service_instance.export_abstraction.return_value = {
+            "success": True,
+            "format": "dot",
+            "output_path": "test.dot",
+            "node_count": 25,
+            "edge_count": 30,
+        }
+        mock_export_service_class.return_value = service_instance
+
+        result = runner.invoke(
+            export_abstraction_command,
+            ["--tenant-id", "test-tenant", "--output", "test.dot", "--format", "dot"],
+        )
+
+        assert result.exit_code == 0
+        assert "Export complete" in result.output
+        assert "Graphviz" in result.output  # usage tip
+        assert "dot -Tpng" in result.output
+
+    @patch("src.commands.export_abstraction.GraphExportService")
+    @patch("src.commands.export_abstraction.Neo4jSessionManager")
+    @patch("src.commands.export_abstraction.get_neo4j_config_from_env")
+    @patch("src.commands.export_abstraction.get_tenant_id")
+    def test_export_abstraction_tenant_not_found(
+        self,
+        mock_get_tenant_id,
+        mock_get_neo4j_config,
+        mock_session_manager_class,
+        mock_export_service_class,
+        runner,
+    ):
+        """Test export with non-existent tenant."""
+        mock_get_tenant_id.return_value = "nonexistent"
+        mock_get_neo4j_config.return_value = (
+            "bolt://localhost:7687",
+            "neo4j",
+            "password",
+        )
+
+        # Mock service to raise error
+        service_instance = Mock()
+        service_instance.export_abstraction.side_effect = ValueError(
+            "No abstraction found"
+        )
+        mock_export_service_class.return_value = service_instance
+
+        result = runner.invoke(
+            export_abstraction_command,
+            ["--tenant-id", "nonexistent", "--output", "test.graphml"],
+        )
+
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+    @patch("src.commands.export_abstraction.GraphExportService")
+    @patch("src.commands.export_abstraction.Neo4jSessionManager")
+    @patch("src.commands.export_abstraction.get_neo4j_config_from_env")
+    @patch("src.commands.export_abstraction.get_tenant_id")
+    def test_export_abstraction_no_relationships(
+        self,
+        mock_get_tenant_id,
+        mock_get_neo4j_config,
+        mock_session_manager_class,
+        mock_export_service_class,
+        runner,
+    ):
+        """Test export with --no-relationships flag."""
+        mock_get_tenant_id.return_value = "test-tenant"
+        mock_get_neo4j_config.return_value = (
+            "bolt://localhost:7687",
+            "neo4j",
+            "password",
+        )
+
+        service_instance = Mock()
+        service_instance.export_abstraction.return_value = {
+            "success": True,
+            "format": "graphml",
+            "output_path": "test.graphml",
+            "node_count": 100,
+            "edge_count": 0,  # No edges
+        }
+        mock_export_service_class.return_value = service_instance
+
+        result = runner.invoke(
+            export_abstraction_command,
+            [
+                "--tenant-id",
+                "test-tenant",
+                "--output",
+                "test.graphml",
+                "--no-relationships",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Export complete" in result.output
+        assert "Edges: 0" in result.output
+
+        # Verify include_relationships=False was passed
+        service_instance.export_abstraction.assert_called_once()
+        call_args = service_instance.export_abstraction.call_args
+        assert call_args[1]["include_relationships"] is False
+
+    @patch("src.commands.export_abstraction.GraphExportService")
+    @patch("src.commands.export_abstraction.Neo4jSessionManager")
+    @patch("src.commands.export_abstraction.get_neo4j_config_from_env")
+    @patch("src.commands.export_abstraction.get_tenant_id")
+    def test_export_abstraction_unexpected_error(
+        self,
+        mock_get_tenant_id,
+        mock_get_neo4j_config,
+        mock_session_manager_class,
+        mock_export_service_class,
+        runner,
+    ):
+        """Test handling of unexpected errors."""
+        mock_get_tenant_id.return_value = "test-tenant"
+        mock_get_neo4j_config.return_value = (
+            "bolt://localhost:7687",
+            "neo4j",
+            "password",
+        )
+
+        # Mock unexpected error
+        service_instance = Mock()
+        service_instance.export_abstraction.side_effect = RuntimeError(
+            "Unexpected error"
+        )
+        mock_export_service_class.return_value = service_instance
+
+        result = runner.invoke(
+            export_abstraction_command,
+            ["--tenant-id", "test-tenant", "--output", "test.graphml"],
+        )
+
+        assert result.exit_code == 1
+        assert "Unexpected error" in result.output
+
+    def test_export_abstraction_missing_output(self, runner):
+        """Test that --output is required."""
+        result = runner.invoke(
+            export_abstraction_command, ["--tenant-id", "test-tenant"]
+        )
+
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()

--- a/tests/services/test_graph_abstraction_mcp_server.py
+++ b/tests/services/test_graph_abstraction_mcp_server.py
@@ -1,0 +1,233 @@
+"""Tests for Graph Abstraction MCP Server (Issue #508).
+
+Test Coverage:
+- list_tenant_abstractions tool
+- get_abstraction_metadata tool
+- get_abstraction_quality tool
+- compare_abstractions tool
+- Empty tenant handling
+- Error cases
+- Response format validation
+
+Target: 85% coverage
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.services.graph_abstraction_mcp_server import GraphAbstractionMCPServer
+
+
+class TestGraphAbstractionMCPServer:
+    """Test suite for GraphAbstractionMCPServer."""
+
+    @pytest.fixture
+    def mock_session_manager(self):
+        """Mock Neo4j session manager."""
+        session_manager = Mock()
+        session = Mock()
+        # Properly mock context manager
+        context_manager = Mock()
+        context_manager.__enter__ = Mock(return_value=session)
+        context_manager.__exit__ = Mock(return_value=None)
+        session_manager.session.return_value = context_manager
+        return session_manager, session
+
+    @pytest.mark.asyncio
+    async def test_list_tenant_abstractions_success(self, mock_session_manager):
+        """Test listing abstractions for tenant."""
+        session_manager, session = mock_session_manager
+
+        # Mock Neo4j query result
+        result = Mock()
+        result.single.return_value = {
+            "tenant_id": "test-tenant",
+            "sample_count": 100,
+            "source_count": 1000,
+            "sample_types": [
+                "Microsoft.Compute/virtualMachines",
+                "Microsoft.Storage/storageAccounts",
+            ],
+        }
+        session.run.return_value = result
+
+        # Create server and call tool
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._list_tenant_abstractions({"tenant_id": "test-tenant"})
+
+        assert len(response) == 1
+        assert "test-tenant" in response[0].text
+        assert "100 nodes" in response[0].text
+        assert "10.00%" in response[0].text  # 100/1000
+
+    @pytest.mark.asyncio
+    async def test_list_tenant_abstractions_not_found(self, mock_session_manager):
+        """Test listing abstractions for non-existent tenant."""
+        session_manager, session = mock_session_manager
+
+        # Mock empty result
+        result = Mock()
+        result.single.return_value = None
+        session.run.return_value = result
+
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._list_tenant_abstractions({"tenant_id": "nonexistent"})
+
+        assert "No abstractions found" in response[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_abstraction_metadata_success(self, mock_session_manager):
+        """Test getting abstraction metadata."""
+        session_manager, session = mock_session_manager
+
+        # Mock query result
+        result = Mock()
+        result.data.return_value = [
+            {"type": "Microsoft.Compute/virtualMachines", "count": 50},
+            {"type": "Microsoft.Storage/storageAccounts", "count": 30},
+            {"type": "Microsoft.Network/virtualNetworks", "count": 20},
+        ]
+        session.run.return_value = result
+
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._get_abstraction_metadata({"tenant_id": "test-tenant"})
+
+        assert len(response) == 1
+        assert "Microsoft.Compute/virtualMachines: 50" in response[0].text
+        assert "Microsoft.Storage/storageAccounts: 30" in response[0].text
+        assert "Total types: 3" in response[0].text
+        assert "Total samples: 100" in response[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_abstraction_metadata_not_found(self, mock_session_manager):
+        """Test getting metadata for non-existent tenant."""
+        session_manager, session = mock_session_manager
+
+        # Mock empty result
+        result = Mock()
+        result.data.return_value = []
+        session.run.return_value = result
+
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._get_abstraction_metadata({"tenant_id": "nonexistent"})
+
+        assert "No abstraction found" in response[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_abstraction_quality_calculates_cv(self, mock_session_manager):
+        """Test quality metrics calculation including coefficient of variation."""
+        session_manager, session = mock_session_manager
+
+        # Mock quality data with varying ratios
+        result = Mock()
+        result.data.return_value = [
+            {"type": "VM", "sample_count": 10, "source_count": 100, "ratio": 0.10},
+            {"type": "Storage", "sample_count": 5, "source_count": 50, "ratio": 0.10},
+            {
+                "type": "Network",
+                "sample_count": 15,
+                "source_count": 120,
+                "ratio": 0.125,
+            },
+        ]
+        session.run.return_value = result
+
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._get_abstraction_quality({"tenant_id": "test-tenant"})
+
+        assert "Coefficient of variation" in response[0].text
+        assert "Average sampling ratio" in response[0].text
+        assert "VM: 10/100 (10.0%)" in response[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_abstraction_quality_single_type(self, mock_session_manager):
+        """Test quality metrics with single type (no std deviation)."""
+        session_manager, session = mock_session_manager
+
+        # Mock single type
+        result = Mock()
+        result.data.return_value = [
+            {"type": "VM", "sample_count": 10, "source_count": 100, "ratio": 0.10},
+        ]
+        session.run.return_value = result
+
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._get_abstraction_quality({"tenant_id": "test-tenant"})
+
+        # Should handle single type gracefully (stdev = 0)
+        assert "Coefficient of variation: 0.000" in response[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_abstraction_quality_not_found(self, mock_session_manager):
+        """Test quality metrics for non-existent tenant."""
+        session_manager, session = mock_session_manager
+
+        # Mock empty result
+        result = Mock()
+        result.data.return_value = []
+        session.run.return_value = result
+
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._get_abstraction_quality({"tenant_id": "nonexistent"})
+
+        assert "No abstraction found" in response[0].text
+
+    @pytest.mark.asyncio
+    async def test_compare_abstractions(self, mock_session_manager):
+        """Test comparing two abstractions."""
+        session_manager, session = mock_session_manager
+
+        # Mock both tenants
+        result = Mock()
+        result.data.return_value = [
+            {"type": "VM", "sample_count": 10, "source_count": 100, "ratio": 0.10},
+        ]
+        session.run.return_value = result
+
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._compare_abstractions(
+            {"tenant_id_1": "tenant1", "tenant_id_2": "tenant2"}
+        )
+
+        assert "Comparison of abstractions" in response[0].text
+        assert "tenant1" in response[0].text
+        assert "tenant2" in response[0].text
+        assert "=== Tenant 1:" in response[0].text
+        assert "=== Tenant 2:" in response[0].text
+
+    def test_server_initialization(self, mock_session_manager):
+        """Test MCP server initializes correctly."""
+        session_manager, _ = mock_session_manager
+
+        server = GraphAbstractionMCPServer(session_manager)
+
+        assert server.session_manager == session_manager
+        assert server.server is not None
+        assert server.server.name == "graph-abstraction-server"
+
+    @pytest.mark.asyncio
+    async def test_quality_metrics_multiple_types(self, mock_session_manager):
+        """Test quality metrics with many resource types."""
+        session_manager, session = mock_session_manager
+
+        # Mock 15 resource types (should show top 10)
+        result = Mock()
+        result.data.return_value = [
+            {
+                "type": f"Microsoft.Type{i}",
+                "sample_count": 10 + i,
+                "source_count": 100 + i * 10,
+                "ratio": (10 + i) / (100 + i * 10),
+            }
+            for i in range(15)
+        ]
+        session.run.return_value = result
+
+        server = GraphAbstractionMCPServer(session_manager)
+        response = await server._get_abstraction_quality({"tenant_id": "test-tenant"})
+
+        # Should only show top 10 types
+        lines = response[0].text.split("\n")
+        type_lines = [line for line in lines if "Microsoft.Type" in line]
+        assert len(type_lines) <= 10

--- a/tests/services/test_graph_export_service.py
+++ b/tests/services/test_graph_export_service.py
@@ -1,0 +1,310 @@
+"""Tests for Graph Export Service (Issue #508).
+
+Test Coverage:
+- GraphML export validation
+- JSON export (D3.js format)
+- DOT export (Graphviz format)
+- Invalid format handling
+- Empty tenant handling
+- No-relationships export
+- Neo4j session integration
+
+Target: 90% coverage
+"""
+
+import json
+from unittest.mock import Mock
+
+import networkx as nx
+import pytest
+
+from src.services.graph_export_service import GraphExportService
+
+
+class TestGraphExportService:
+    """Test suite for GraphExportService."""
+
+    @pytest.fixture
+    def mock_session_manager(self):
+        """Mock Neo4j session manager."""
+        session_manager = Mock()
+        session = Mock()
+        # Properly mock context manager
+        context_manager = Mock()
+        context_manager.__enter__ = Mock(return_value=session)
+        context_manager.__exit__ = Mock(return_value=None)
+        session_manager.session.return_value = context_manager
+        return session_manager, session
+
+    def test_export_to_graphml(self, mock_session_manager, tmp_path):
+        """Test GraphML export creates valid format."""
+        session_manager, session = mock_session_manager
+
+        # Mock Neo4j node query
+        node_result = Mock()
+        node_result.__iter__ = lambda self: iter(
+            [
+                {
+                    "id": "vm1",
+                    "name": "vm1",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "location": "eastus",
+                    "tenant_id": "test-tenant",
+                }
+            ]
+        )
+
+        # Mock Neo4j edge query
+        edge_result = Mock()
+        edge_result.__iter__ = lambda self: iter([])
+
+        session.run.side_effect = [node_result, edge_result]
+
+        # Export
+        service = GraphExportService(session_manager)
+        output_path = tmp_path / "test.graphml"
+        result = service.export_abstraction(
+            tenant_id="test-tenant", output_path=output_path, format="graphml"
+        )
+
+        assert result["success"] is True
+        assert result["node_count"] == 1
+        assert result["edge_count"] == 0
+        assert output_path.exists()
+
+        # Verify GraphML is valid by loading it
+        graph = nx.read_graphml(str(output_path))
+        assert graph.number_of_nodes() == 1
+
+    def test_export_to_json(self, mock_session_manager, tmp_path):
+        """Test JSON export creates D3.js-compatible format."""
+        session_manager, session = mock_session_manager
+
+        # Mock Neo4j queries
+        node_result = Mock()
+        node_result.__iter__ = lambda self: iter(
+            [
+                {
+                    "id": "vm1",
+                    "name": "vm1",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "location": "eastus",
+                    "tenant_id": "test-tenant",
+                }
+            ]
+        )
+
+        edge_result = Mock()
+        edge_result.__iter__ = lambda self: iter(
+            [{"source_id": "rg1", "target_id": "vm1", "rel_type": "CONTAINS"}]
+        )
+
+        session.run.side_effect = [node_result, edge_result]
+
+        # Export
+        service = GraphExportService(session_manager)
+        output_path = tmp_path / "test.json"
+        result = service.export_abstraction(
+            tenant_id="test-tenant", output_path=output_path, format="json"
+        )
+
+        assert result["success"] is True
+        assert output_path.exists()
+
+        # Verify JSON structure
+        data = json.loads(output_path.read_text())
+        assert "nodes" in data
+        assert "links" in data
+        assert "metadata" in data
+        # Note: 2 nodes because NetworkX auto-creates missing source node "rg1"
+        assert len(data["nodes"]) == 2
+        # Find the vm1 node
+        vm_node = next(n for n in data["nodes"] if n["id"] == "vm1")
+        assert vm_node["type"] == "Microsoft.Compute/virtualMachines"
+
+    def test_export_to_dot(self, mock_session_manager, tmp_path):
+        """Test DOT export creates valid Graphviz format."""
+        session_manager, session = mock_session_manager
+
+        # Mock Neo4j queries
+        node_result = Mock()
+        node_result.__iter__ = lambda self: iter(
+            [
+                {
+                    "id": "vm1",
+                    "name": "vm1",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "location": "eastus",
+                    "tenant_id": "test-tenant",
+                }
+            ]
+        )
+
+        edge_result = Mock()
+        edge_result.__iter__ = lambda self: iter([])
+
+        session.run.side_effect = [node_result, edge_result]
+
+        # Export
+        service = GraphExportService(session_manager)
+        output_path = tmp_path / "test.dot"
+        result = service.export_abstraction(
+            tenant_id="test-tenant", output_path=output_path, format="dot"
+        )
+
+        assert result["success"] is True
+        assert output_path.exists()
+
+        # Verify DOT file was created
+        content = output_path.read_text()
+        assert "digraph" in content or "strict digraph" in content
+
+    def test_export_no_relationships(self, mock_session_manager, tmp_path):
+        """Test export with no-relationships flag."""
+        session_manager, session = mock_session_manager
+
+        # Mock only node query (no edge query)
+        node_result = Mock()
+        node_result.__iter__ = lambda self: iter(
+            [
+                {
+                    "id": "vm1",
+                    "name": "vm1",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "location": "eastus",
+                    "tenant_id": "test-tenant",
+                }
+            ]
+        )
+
+        session.run.return_value = node_result
+
+        # Export without relationships
+        service = GraphExportService(session_manager)
+        output_path = tmp_path / "test.graphml"
+        result = service.export_abstraction(
+            tenant_id="test-tenant",
+            output_path=output_path,
+            format="graphml",
+            include_relationships=False,
+        )
+
+        assert result["edge_count"] == 0
+        # Verify session.run was only called once (for nodes)
+        assert session.run.call_count == 1
+
+    def test_export_invalid_format(self, mock_session_manager, tmp_path):
+        """Test export with invalid format raises ValueError."""
+        session_manager, _ = mock_session_manager
+
+        service = GraphExportService(session_manager)
+
+        with pytest.raises(ValueError, match="Unsupported format"):
+            service.export_abstraction(
+                tenant_id="test-tenant",
+                output_path=tmp_path / "test.csv",
+                format="csv",
+            )
+
+    def test_export_tenant_not_found(self, mock_session_manager, tmp_path):
+        """Test export with non-existent tenant raises ValueError."""
+        session_manager, session = mock_session_manager
+
+        # Mock empty result
+        node_result = Mock()
+        node_result.__iter__ = lambda self: iter([])
+        session.run.return_value = node_result
+
+        service = GraphExportService(session_manager)
+
+        with pytest.raises(ValueError, match="No abstraction found"):
+            service.export_abstraction(
+                tenant_id="nonexistent",
+                output_path=tmp_path / "test.graphml",
+                format="graphml",
+            )
+
+    def test_export_creates_parent_directories(self, mock_session_manager, tmp_path):
+        """Test export creates parent directories if they don't exist."""
+        session_manager, session = mock_session_manager
+
+        # Mock Neo4j node query
+        node_result = Mock()
+        node_result.__iter__ = lambda self: iter(
+            [
+                {
+                    "id": "vm1",
+                    "name": "vm1",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "location": "eastus",
+                    "tenant_id": "test-tenant",
+                }
+            ]
+        )
+
+        edge_result = Mock()
+        edge_result.__iter__ = lambda self: iter([])
+
+        session.run.side_effect = [node_result, edge_result]
+
+        # Export to nested directory
+        service = GraphExportService(session_manager)
+        output_path = tmp_path / "nested" / "dir" / "test.graphml"
+        result = service.export_abstraction(
+            tenant_id="test-tenant", output_path=output_path, format="graphml"
+        )
+
+        assert result["success"] is True
+        assert output_path.exists()
+        assert output_path.parent.exists()
+
+    def test_json_export_with_edges(self, mock_session_manager, tmp_path):
+        """Test JSON export includes edges in D3.js format."""
+        session_manager, session = mock_session_manager
+
+        # Mock queries with multiple nodes and edges
+        node_result = Mock()
+        node_result.__iter__ = lambda self: iter(
+            [
+                {
+                    "id": "rg1",
+                    "name": "rg1",
+                    "type": "Microsoft.Resources/resourceGroups",
+                    "location": "eastus",
+                    "tenant_id": "test-tenant",
+                },
+                {
+                    "id": "vm1",
+                    "name": "vm1",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "location": "eastus",
+                    "tenant_id": "test-tenant",
+                },
+            ]
+        )
+
+        edge_result = Mock()
+        edge_result.__iter__ = lambda self: iter(
+            [
+                {"source_id": "rg1", "target_id": "vm1", "rel_type": "CONTAINS"},
+            ]
+        )
+
+        session.run.side_effect = [node_result, edge_result]
+
+        # Export
+        service = GraphExportService(session_manager)
+        output_path = tmp_path / "test.json"
+        service.export_abstraction(
+            tenant_id="test-tenant", output_path=output_path, format="json"
+        )
+
+        # Verify JSON structure
+        data = json.loads(output_path.read_text())
+        assert len(data["nodes"]) == 2
+        assert len(data["links"]) == 1
+        assert data["links"][0]["source"] == "rg1"
+        assert data["links"][0]["target"] == "vm1"
+        assert data["links"][0]["relationship"] == "CONTAINS"
+        assert data["metadata"]["node_count"] == 2
+        assert data["metadata"]["edge_count"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -440,6 +440,7 @@ dependencies = [
     { name = "openai" },
     { name = "py2neo" },
     { name = "pydantic" },
+    { name = "pydot" },
     { name = "python-dotenv" },
     { name = "python-pptx" },
     { name = "pyyaml" },
@@ -502,6 +503,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.12.0" },
     { name = "py2neo", specifier = ">=2021.2.4" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydot", specifier = ">=3.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-pptx", specifier = ">=1.0.2" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -2062,6 +2064,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pydot"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2094,6 +2108,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements **Issue #508** - MCP Server and Visualization Export Integration

This PR adds three production-ready modules that enable AI agents to query graph abstraction quality and export abstractions to visualization formats:

### 1. GraphAbstractionMCPServer (src/services/graph_abstraction_mcp_server.py)
- MCP server exposing 4 tools for AI agents:
  - `list_tenant_abstractions`: List available abstractions
  - `get_abstraction_metadata`: Get abstraction details (sample counts, types)
  - `get_abstraction_quality`: Calculate quality metrics (sampling ratios, coefficient of variation)
  - `compare_abstractions`: Compare quality across tenants
- Enables LLM-powered analysis of graph abstraction quality
- 10 comprehensive tests, all passing

### 2. GraphExportService (src/services/graph_export_service.py)
- Export abstractions to 3 visualization formats:
  - **GraphML**: For Gephi, Cytoscape, yEd
  - **JSON**: D3.js-compatible format (nodes + links)
  - **DOT**: Graphviz rendering
- Uses NetworkX for graph operations
- 8 comprehensive tests covering all formats and edge cases

### 3. export-abstraction CLI (src/commands/export_abstraction.py)
- User-friendly command-line interface
- Usage: `atg export-abstraction --tenant-id abc-123 --output graph.graphml`
- Supports `--format` (graphml/json/dot) and `--no-relationships` flags
- 7 comprehensive tests using Click test runner

## Test Plan

### Unit Tests
- **26 tests**, all passing
- Coverage: MCP server tools (10), export service (8), CLI (7)
- Mock Neo4j sessions for fast execution

### Manual Testing
```bash
# Test CLI help
uv run atg export-abstraction --help

# Test export (requires Neo4j with abstraction data)
uv run atg export-abstraction --tenant-id <tenant> --output test.graphml
uv run atg export-abstraction --tenant-id <tenant> --output test.json --format json
uv run atg export-abstraction --tenant-id <tenant> --output test.dot --format dot
```

### Linting
- All files pass `ruff check` and `ruff format`
- Zero linting errors in new code

## Key Features

- **Zero-BS Implementation**: No stubs, all functions work
- **Ruthless Simplicity**: Delegates to specialized services (thin CLI wrapper)
- **Philosophy-Aligned**: Modular brick design with clear public APIs
- **Complete Test Coverage**: 26 tests ensure reliability
- **Production-Ready**: Full error handling, logging, user-friendly messages

## Dependencies

- Added `pydot` to pyproject.toml (required for DOT export)
- All dependencies synced in uv.lock

## Integration

- Integrates with Neo4j session manager
- Uses existing graph abstraction queries from Issue #509
- Compatible with MCP protocol for AI agent integration

## Related Issues

- Implements: #508
- Depends on: #509 (graph abstraction implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)