### PR TITLE
refactor: Extract layer commands (CLI Phase 3)

### DIFF
--- a/src/commands/layer_cmd.py
+++ b/src/commands/layer_cmd.py
@@ -1,0 +1,693 @@
+"""Layer management command group.
+
+This module provides the layer command group for multi-layer graph projection management:
+- layer list: List all layers with filtering and sorting
+- layer show: Display detailed layer information
+- layer active: Show or set active layer
+- layer create: Create new empty layer
+- layer copy: Duplicate layer with all nodes/relationships
+- layer delete: Remove layer and its data
+- layer diff: Compare two layers
+- layer validate: Check layer integrity
+- layer refresh-stats: Update layer metadata counts
+- layer archive: Export layer to JSON
+- layer restore: Import layer from JSON archive
+
+Issue #482: CLI Modularization - Phase 3 (Layer Commands)
+"""
+
+from typing import Optional
+
+import click
+
+from src.cli_commands_layer import (
+    layer_active_command_handler,
+    layer_archive_command_handler,
+    layer_copy_command_handler,
+    layer_create_command_handler,
+    layer_delete_command_handler,
+    layer_diff_command_handler,
+    layer_list_command_handler,
+    layer_refresh_stats_command_handler,
+    layer_restore_command_handler,
+    layer_show_command_handler,
+    layer_validate_command_handler,
+)
+
+
+def async_command(f):
+    """Decorator to run async command handlers."""
+    import asyncio
+    import functools
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+# =============================================================================
+# Layer Command Group
+# =============================================================================
+
+
+@click.group(name="layer")
+def layer() -> None:
+    """Layer management commands for multi-layer graph projections."""
+    pass
+
+
+# =============================================================================
+# layer list
+# =============================================================================
+
+
+@layer.command(name="list")
+@click.option(
+    "--tenant-id",
+    help="Filter by tenant ID",
+)
+@click.option(
+    "--include-inactive/--active-only",
+    default=True,
+    help="Show inactive layers (default: true)",
+)
+@click.option(
+    "--type",
+    "layer_type",
+    type=click.Choice(
+        ["baseline", "scaled", "experimental", "snapshot"], case_sensitive=False
+    ),
+    help="Filter by layer type",
+)
+@click.option(
+    "--sort-by",
+    type=click.Choice(["name", "created_at", "node_count"], case_sensitive=False),
+    default="created_at",
+    help="Sort field (default: created_at)",
+)
+@click.option(
+    "--ascending/--descending",
+    default=False,
+    help="Sort order (default: descending)",
+)
+@click.option(
+    "--format",
+    "format_type",
+    type=click.Choice(["table", "json", "yaml"], case_sensitive=False),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_list(
+    ctx: click.Context,
+    tenant_id: Optional[str],
+    include_inactive: bool,
+    layer_type: Optional[str],
+    sort_by: str,
+    ascending: bool,
+    format_type: str,
+    no_container: bool,
+) -> None:
+    """List all layers with summary information."""
+    debug = ctx.obj.get("debug", False)
+    await layer_list_command_handler(
+        tenant_id=tenant_id,
+        include_inactive=include_inactive,
+        layer_type=layer_type,
+        sort_by=sort_by,
+        ascending=ascending,
+        format_type=format_type,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer show
+# =============================================================================
+
+
+@layer.command(name="show")
+@click.argument("layer_id")
+@click.option(
+    "--format",
+    "format_type",
+    type=click.Choice(["text", "json", "yaml"], case_sensitive=False),
+    default="text",
+    help="Output format (default: text)",
+)
+@click.option(
+    "--show-stats",
+    is_flag=True,
+    help="Include detailed statistics",
+)
+@click.option(
+    "--show-lineage",
+    is_flag=True,
+    help="Show parent/child layers",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_show(
+    ctx: click.Context,
+    layer_id: str,
+    format_type: str,
+    show_stats: bool,
+    show_lineage: bool,
+    no_container: bool,
+) -> None:
+    """Show detailed information about a specific layer."""
+    debug = ctx.obj.get("debug", False)
+    await layer_show_command_handler(
+        layer_id=layer_id,
+        format_type=format_type,
+        show_stats=show_stats,
+        show_lineage=show_lineage,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer active
+# =============================================================================
+
+
+@layer.command(name="active")
+@click.argument("layer_id", required=False)
+@click.option(
+    "--tenant-id",
+    help="Tenant context (for multi-tenant)",
+)
+@click.option(
+    "--format",
+    "format_type",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_active(
+    ctx: click.Context,
+    layer_id: Optional[str],
+    tenant_id: Optional[str],
+    format_type: str,
+    no_container: bool,
+) -> None:
+    """Show or set the active layer."""
+    debug = ctx.obj.get("debug", False)
+    await layer_active_command_handler(
+        layer_id=layer_id,
+        tenant_id=tenant_id,
+        format_type=format_type,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer create
+# =============================================================================
+
+
+@layer.command(name="create")
+@click.argument("layer_id")
+@click.option(
+    "--name",
+    help="Human-readable name (default: layer_id)",
+)
+@click.option(
+    "--description",
+    help="Layer description",
+)
+@click.option(
+    "--type",
+    "layer_type",
+    type=click.Choice(
+        ["baseline", "scaled", "experimental", "snapshot"], case_sensitive=False
+    ),
+    default="experimental",
+    help="Layer type (default: experimental)",
+)
+@click.option(
+    "--parent-layer",
+    help="Parent layer for lineage",
+)
+@click.option(
+    "--tenant-id",
+    help="Tenant ID",
+)
+@click.option(
+    "--tag",
+    "tags",
+    multiple=True,
+    help="Add tag (multiple allowed)",
+)
+@click.option(
+    "--make-active",
+    is_flag=True,
+    help="Set as active layer",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_create(
+    ctx: click.Context,
+    layer_id: str,
+    name: Optional[str],
+    description: Optional[str],
+    layer_type: str,
+    parent_layer: Optional[str],
+    tenant_id: Optional[str],
+    tags: tuple,
+    make_active: bool,
+    yes: bool,
+    no_container: bool,
+) -> None:
+    """Create a new empty layer."""
+    debug = ctx.obj.get("debug", False)
+    await layer_create_command_handler(
+        layer_id=layer_id,
+        name=name,
+        description=description,
+        layer_type=layer_type,
+        parent_layer=parent_layer,
+        tenant_id=tenant_id,
+        tags=list(tags),
+        make_active=make_active,
+        yes=yes,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer copy
+# =============================================================================
+
+
+@layer.command(name="copy")
+@click.argument("source")
+@click.argument("target")
+@click.option(
+    "--name",
+    help="Name for new layer",
+)
+@click.option(
+    "--description",
+    help="Description for new layer",
+)
+@click.option(
+    "--copy-metadata/--no-copy-metadata",
+    default=True,
+    help="Copy metadata dict from source (default: true)",
+)
+@click.option(
+    "--make-active",
+    is_flag=True,
+    help="Set new layer as active",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_copy(
+    ctx: click.Context,
+    source: str,
+    target: str,
+    name: Optional[str],
+    description: Optional[str],
+    copy_metadata: bool,
+    make_active: bool,
+    yes: bool,
+    no_container: bool,
+) -> None:
+    """Copy an entire layer (nodes + relationships)."""
+    debug = ctx.obj.get("debug", False)
+    await layer_copy_command_handler(
+        source=source,
+        target=target,
+        name=name,
+        description=description,
+        copy_metadata=copy_metadata,
+        make_active=make_active,
+        yes=yes,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer delete
+# =============================================================================
+
+
+@layer.command(name="delete")
+@click.argument("layer_id")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Allow deletion of active/baseline layers",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation",
+)
+@click.option(
+    "--archive",
+    type=click.Path(dir_okay=False, writable=True),
+    help="Archive layer before deletion",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_delete(
+    ctx: click.Context,
+    layer_id: str,
+    force: bool,
+    yes: bool,
+    archive: Optional[str],
+    no_container: bool,
+) -> None:
+    """Delete a layer and all its nodes/relationships."""
+    debug = ctx.obj.get("debug", False)
+    await layer_delete_command_handler(
+        layer_id=layer_id,
+        force=force,
+        yes=yes,
+        archive=archive,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer diff
+# =============================================================================
+
+
+@layer.command(name="diff")
+@click.argument("layer_a")
+@click.argument("layer_b")
+@click.option(
+    "--detailed",
+    is_flag=True,
+    help="Include node IDs in output",
+)
+@click.option(
+    "--properties",
+    is_flag=True,
+    help="Compare property values",
+)
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, writable=True),
+    help="Save report to file",
+)
+@click.option(
+    "--format",
+    "format_type",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format (default: text)",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_diff(
+    ctx: click.Context,
+    layer_a: str,
+    layer_b: str,
+    detailed: bool,
+    properties: bool,
+    output: Optional[str],
+    format_type: str,
+    no_container: bool,
+) -> None:
+    """Compare two layers to find differences."""
+    debug = ctx.obj.get("debug", False)
+    await layer_diff_command_handler(
+        layer_a=layer_a,
+        layer_b=layer_b,
+        detailed=detailed,
+        properties=properties,
+        output=output,
+        format_type=format_type,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer validate
+# =============================================================================
+
+
+@layer.command(name="validate")
+@click.argument("layer_id")
+@click.option(
+    "--fix",
+    is_flag=True,
+    help="Attempt automatic fixes",
+)
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, writable=True),
+    help="Save report to file",
+)
+@click.option(
+    "--format",
+    "format_type",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format (default: text)",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_validate(
+    ctx: click.Context,
+    layer_id: str,
+    fix: bool,
+    output: Optional[str],
+    format_type: str,
+    no_container: bool,
+) -> None:
+    """Validate layer integrity and check for issues."""
+    debug = ctx.obj.get("debug", False)
+    await layer_validate_command_handler(
+        layer_id=layer_id,
+        fix=fix,
+        output=output,
+        format_type=format_type,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer refresh-stats
+# =============================================================================
+
+
+@layer.command(name="refresh-stats")
+@click.argument("layer_id")
+@click.option(
+    "--format",
+    "format_type",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_refresh_stats(
+    ctx: click.Context,
+    layer_id: str,
+    format_type: str,
+    no_container: bool,
+) -> None:
+    """Refresh layer metadata statistics."""
+    debug = ctx.obj.get("debug", False)
+    await layer_refresh_stats_command_handler(
+        layer_id=layer_id,
+        format_type=format_type,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer archive
+# =============================================================================
+
+
+@layer.command(name="archive")
+@click.argument("layer_id")
+@click.argument("output_path", type=click.Path(dir_okay=False, writable=True))
+@click.option(
+    "--include-original",
+    is_flag=True,
+    help="Include Original nodes in archive",
+)
+@click.option(
+    "--compress",
+    is_flag=True,
+    help="Compress archive with gzip",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_archive(
+    ctx: click.Context,
+    layer_id: str,
+    output_path: str,
+    include_original: bool,
+    compress: bool,
+    yes: bool,
+    no_container: bool,
+) -> None:
+    """Export layer to JSON archive file."""
+    debug = ctx.obj.get("debug", False)
+    await layer_archive_command_handler(
+        layer_id=layer_id,
+        output_path=output_path,
+        include_original=include_original,
+        compress=compress,
+        yes=yes,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# layer restore
+# =============================================================================
+
+
+@layer.command(name="restore")
+@click.argument(
+    "archive_path", type=click.Path(exists=True, dir_okay=False, readable=True)
+)
+@click.option(
+    "--layer-id",
+    help="Override layer ID from archive",
+)
+@click.option(
+    "--make-active",
+    is_flag=True,
+    help="Set as active layer after restore",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation",
+)
+@click.option(
+    "--no-container",
+    is_flag=True,
+    help="Do not auto-start Neo4j container",
+)
+@click.pass_context
+@async_command
+async def layer_restore(
+    ctx: click.Context,
+    archive_path: str,
+    layer_id: Optional[str],
+    make_active: bool,
+    yes: bool,
+    no_container: bool,
+) -> None:
+    """Restore layer from JSON archive."""
+    debug = ctx.obj.get("debug", False)
+    await layer_restore_command_handler(
+        archive_path=archive_path,
+        layer_id=layer_id,
+        make_active=make_active,
+        yes=yes,
+        no_container=no_container,
+        debug=debug,
+    )
+
+
+# =============================================================================
+# Exports
+# =============================================================================
+
+__all__ = [
+    "layer",
+    "layer_list",
+    "layer_show",
+    "layer_active",
+    "layer_create",
+    "layer_copy",
+    "layer_delete",
+    "layer_diff",
+    "layer_validate",
+    "layer_refresh_stats",
+    "layer_archive",
+    "layer_restore",
+]

--- a/tests/commands/test_layer.py
+++ b/tests/commands/test_layer.py
@@ -1,0 +1,580 @@
+"""Tests for layer management CLI commands (Issue #482 - Phase 3).
+
+Test Coverage:
+- Help text for all layer commands
+- Command invocation with various options
+- Backward compatibility with cli.py
+- Error handling and validation
+- Handler delegation
+
+Target: 80% coverage
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from src.commands.layer_cmd import (
+    layer,
+    layer_active,
+    layer_archive,
+    layer_copy,
+    layer_create,
+    layer_delete,
+    layer_diff,
+    layer_list,
+    layer_refresh_stats,
+    layer_restore,
+    layer_show,
+    layer_validate,
+)
+
+
+class TestLayerGroup:
+    """Test suite for layer command group."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_group_help(self, runner):
+        """Test layer group help text displays correctly."""
+        result = runner.invoke(layer, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Layer management commands" in result.output
+        assert "list" in result.output
+        assert "show" in result.output
+        assert "create" in result.output
+
+
+class TestLayerListCommand:
+    """Test suite for layer list CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_list_help(self, runner):
+        """Test layer list help text displays correctly."""
+        result = runner.invoke(layer_list, ["--help"])
+
+        assert result.exit_code == 0
+        assert "List all layers" in result.output
+        assert "--tenant-id" in result.output
+        assert "--format" in result.output
+
+    @patch("src.commands.layer_cmd.layer_list_command_handler")
+    def test_layer_list_basic(self, mock_handler, runner):
+        """Test basic layer list invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_list, [], obj={"debug": False}, catch_exceptions=False
+        )
+
+        # Command should complete
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["tenant_id"] is None
+        assert call_args["include_inactive"] is True
+        assert call_args["format_type"] == "table"
+        assert call_args["debug"] is False
+
+    @patch("src.commands.layer_cmd.layer_list_command_handler")
+    def test_layer_list_with_filters(self, mock_handler, runner):
+        """Test layer list with filtering options."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_list,
+            [
+                "--tenant-id",
+                "test-tenant",
+                "--type",
+                "baseline",
+                "--sort-by",
+                "name",
+                "--ascending",
+                "--format",
+                "json",
+            ],
+            obj={"debug": True},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["tenant_id"] == "test-tenant"
+        assert call_args["layer_type"] == "baseline"
+        assert call_args["sort_by"] == "name"
+        assert call_args["ascending"] is True
+        assert call_args["format_type"] == "json"
+
+
+class TestLayerShowCommand:
+    """Test suite for layer show CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_show_help(self, runner):
+        """Test layer show help text displays correctly."""
+        result = runner.invoke(layer_show, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Show detailed information" in result.output
+        assert "--format" in result.output
+        assert "--show-stats" in result.output
+
+    @patch("src.commands.layer_cmd.layer_show_command_handler")
+    def test_layer_show_basic(self, mock_handler, runner):
+        """Test basic layer show invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_show, ["test-layer"], obj={"debug": False}, catch_exceptions=False
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_id"] == "test-layer"
+        assert call_args["format_type"] == "text"
+        assert call_args["show_stats"] is False
+
+
+class TestLayerActiveCommand:
+    """Test suite for layer active CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_active_help(self, runner):
+        """Test layer active help text displays correctly."""
+        result = runner.invoke(layer_active, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Show or set the active layer" in result.output
+
+    @patch("src.commands.layer_cmd.layer_active_command_handler")
+    def test_layer_active_show(self, mock_handler, runner):
+        """Test showing current active layer."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_active, [], obj={"debug": False}, catch_exceptions=False
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_id"] is None
+
+    @patch("src.commands.layer_cmd.layer_active_command_handler")
+    def test_layer_active_set(self, mock_handler, runner):
+        """Test setting active layer."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_active,
+            ["test-layer"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_id"] == "test-layer"
+
+
+class TestLayerCreateCommand:
+    """Test suite for layer create CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_create_help(self, runner):
+        """Test layer create help text displays correctly."""
+        result = runner.invoke(layer_create, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Create a new empty layer" in result.output
+        assert "--name" in result.output
+        assert "--type" in result.output
+
+    @patch("src.commands.layer_cmd.layer_create_command_handler")
+    def test_layer_create_basic(self, mock_handler, runner):
+        """Test basic layer create invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_create,
+            ["new-layer", "--yes"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_id"] == "new-layer"
+        assert call_args["layer_type"] == "experimental"
+        assert call_args["yes"] is True
+
+    @patch("src.commands.layer_cmd.layer_create_command_handler")
+    def test_layer_create_with_options(self, mock_handler, runner):
+        """Test layer create with various options."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_create,
+            [
+                "new-layer",
+                "--name",
+                "Test Layer",
+                "--description",
+                "Test description",
+                "--type",
+                "baseline",
+                "--parent-layer",
+                "parent-layer",
+                "--tag",
+                "test",
+                "--tag",
+                "prod",
+                "--make-active",
+                "--yes",
+            ],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["name"] == "Test Layer"
+        assert call_args["description"] == "Test description"
+        assert call_args["layer_type"] == "baseline"
+        assert call_args["parent_layer"] == "parent-layer"
+        assert call_args["tags"] == ["test", "prod"]
+        assert call_args["make_active"] is True
+
+
+class TestLayerCopyCommand:
+    """Test suite for layer copy CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_copy_help(self, runner):
+        """Test layer copy help text displays correctly."""
+        result = runner.invoke(layer_copy, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Copy an entire layer" in result.output
+
+    @patch("src.commands.layer_cmd.layer_copy_command_handler")
+    def test_layer_copy_basic(self, mock_handler, runner):
+        """Test basic layer copy invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_copy,
+            ["source-layer", "target-layer", "--yes"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["source"] == "source-layer"
+        assert call_args["target"] == "target-layer"
+        assert call_args["copy_metadata"] is True
+
+
+class TestLayerDeleteCommand:
+    """Test suite for layer delete CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_delete_help(self, runner):
+        """Test layer delete help text displays correctly."""
+        result = runner.invoke(layer_delete, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Delete a layer" in result.output
+        assert "--force" in result.output
+
+    @patch("src.commands.layer_cmd.layer_delete_command_handler")
+    def test_layer_delete_basic(self, mock_handler, runner):
+        """Test basic layer delete invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_delete,
+            ["test-layer", "--yes"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_id"] == "test-layer"
+        assert call_args["force"] is False
+        assert call_args["yes"] is True
+
+    @patch("src.commands.layer_cmd.layer_delete_command_handler")
+    def test_layer_delete_with_archive(self, mock_handler, runner):
+        """Test layer delete with archiving."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_delete,
+            ["test-layer", "--archive", "/tmp/backup.json", "--force", "--yes"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["archive"] == "/tmp/backup.json"
+        assert call_args["force"] is True
+
+
+class TestLayerDiffCommand:
+    """Test suite for layer diff CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_diff_help(self, runner):
+        """Test layer diff help text displays correctly."""
+        result = runner.invoke(layer_diff, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Compare two layers" in result.output
+        assert "--detailed" in result.output
+
+    @patch("src.commands.layer_cmd.layer_diff_command_handler")
+    def test_layer_diff_basic(self, mock_handler, runner):
+        """Test basic layer diff invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_diff,
+            ["layer-a", "layer-b"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_a"] == "layer-a"
+        assert call_args["layer_b"] == "layer-b"
+        assert call_args["detailed"] is False
+        assert call_args["properties"] is False
+
+
+class TestLayerValidateCommand:
+    """Test suite for layer validate CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_validate_help(self, runner):
+        """Test layer validate help text displays correctly."""
+        result = runner.invoke(layer_validate, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Validate layer integrity" in result.output
+        assert "--fix" in result.output
+
+    @patch("src.commands.layer_cmd.layer_validate_command_handler")
+    def test_layer_validate_basic(self, mock_handler, runner):
+        """Test basic layer validate invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_validate,
+            ["test-layer"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_id"] == "test-layer"
+        assert call_args["fix"] is False
+
+
+class TestLayerRefreshStatsCommand:
+    """Test suite for layer refresh-stats CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_refresh_stats_help(self, runner):
+        """Test layer refresh-stats help text displays correctly."""
+        result = runner.invoke(layer_refresh_stats, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Refresh layer metadata" in result.output
+
+    @patch("src.commands.layer_cmd.layer_refresh_stats_command_handler")
+    def test_layer_refresh_stats_basic(self, mock_handler, runner):
+        """Test basic layer refresh-stats invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_refresh_stats,
+            ["test-layer"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_id"] == "test-layer"
+
+
+class TestLayerArchiveCommand:
+    """Test suite for layer archive CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_archive_help(self, runner):
+        """Test layer archive help text displays correctly."""
+        result = runner.invoke(layer_archive, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Export layer to JSON" in result.output
+        assert "--include-original" in result.output
+
+    @patch("src.commands.layer_cmd.layer_archive_command_handler")
+    def test_layer_archive_basic(self, mock_handler, runner):
+        """Test basic layer archive invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        result = runner.invoke(
+            layer_archive,
+            ["test-layer", "/tmp/archive.json", "--yes"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["layer_id"] == "test-layer"
+        assert call_args["output_path"] == "/tmp/archive.json"
+        assert call_args["include_original"] is False
+
+
+class TestLayerRestoreCommand:
+    """Test suite for layer restore CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_layer_restore_help(self, runner):
+        """Test layer restore help text displays correctly."""
+        result = runner.invoke(layer_restore, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Restore layer from JSON" in result.output
+        assert "--layer-id" in result.output
+
+    @patch("src.commands.layer_cmd.layer_restore_command_handler")
+    def test_layer_restore_basic(self, mock_handler, runner, tmp_path):
+        """Test basic layer restore invocation."""
+        mock_handler.return_value = AsyncMock()
+
+        # Create a temporary archive file
+        archive_file = tmp_path / "archive.json"
+        archive_file.write_text("{}")
+
+        result = runner.invoke(
+            layer_restore,
+            [str(archive_file), "--yes"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+        call_args = mock_handler.call_args[1]
+        assert call_args["archive_path"] == str(archive_file)
+        assert call_args["layer_id"] is None
+        assert call_args["make_active"] is False
+
+
+class TestBackwardCompatibility:
+    """Test suite for backward compatibility with cli.py."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    @patch("src.commands.layer_cmd.layer_list_command_handler")
+    def test_layer_group_works_as_subcommand(self, mock_handler, runner):
+        """Test layer command group works when registered to main CLI."""
+        mock_handler.return_value = AsyncMock()
+
+        # Import and register layer group to test CLI
+        from click import Group
+
+        test_cli = Group()
+        test_cli.add_command(layer)
+
+        result = runner.invoke(
+            test_cli,
+            ["layer", "list"],
+            obj={"debug": False},
+            catch_exceptions=False,
+        )
+
+        assert mock_handler.called
+
+    def test_all_commands_exported(self):
+        """Test all commands are properly exported."""
+        from src.commands import layer_cmd
+
+        expected_exports = [
+            "layer",
+            "layer_list",
+            "layer_show",
+            "layer_active",
+            "layer_create",
+            "layer_copy",
+            "layer_delete",
+            "layer_diff",
+            "layer_validate",
+            "layer_refresh_stats",
+            "layer_archive",
+            "layer_restore",
+        ]
+
+        for export in expected_exports:
+            assert hasattr(layer_cmd, export), f"Missing export: {export}"
+            assert export in layer_cmd.__all__, f"Export not in __all__: {export}"


### PR DESCRIPTION
CLI modularization Phase 3. Extracts layer command group with 11 subcommands. -586 lines from cli.py. Related: Issue #482