### PR TITLE
fix: VMs not generated - subset filter bug (Issue #594)

### DIFF
--- a/src/iac/emitters/terraform_emitter.py
+++ b/src/iac/emitters/terraform_emitter.py
@@ -184,8 +184,7 @@ class TerraformEmitter(IaCEmitter):
 
     # Azure resource type to Terraform resource type mapping
     AZURE_TO_TERRAFORM_MAPPING: ClassVar[Dict[str, str]] = {
-        # Bug #NEW4: VMs removed - handler detects Windows vs Linux, import blocks can't
-        # "Microsoft.Compute/virtualMachines": "azurerm_linux_virtual_machine",  # REMOVED - let handler decide
+        "Microsoft.Compute/virtualMachines": "azurerm_linux_virtual_machine",  # Fix #594: Re-add to prevent UNSUPPORTED marking (handler dynamically chooses linux/windows)
         "Microsoft.Compute/disks": "azurerm_managed_disk",
         "Microsoft.Compute/virtualMachines/extensions": "azurerm_virtual_machine_extension",
         "Microsoft.Storage/storageAccounts": "azurerm_storage_account",

--- a/src/iac/subset.py
+++ b/src/iac/subset.py
@@ -287,14 +287,17 @@ class SubsetSelector:
                         included.add(resource_id)
             return included
 
-        # 7. resource_group (query Neo4j for RG resources)
+        # 7. resource_group - Fix #594: Check property not just ID format
         if filter_config.resource_group:
             included = set()
             for resource in graph.resources:
                 resource_id = resource.get("id")
-                # Extract RG name from resource ID
-                # Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/...
-                if resource_id and "/resourceGroups/" in resource_id:
+                # Fix #594: Check resource_group property (works for Abstracted + Original nodes)
+                rg = resource.get("resource_group") or resource.get("resourceGroup")
+                if rg and rg in filter_config.resource_group:
+                    included.add(resource_id)
+                # Fallback: Also check ID format for backwards compatibility
+                elif resource_id and "/resourceGroups/" in resource_id:
                     parts = resource_id.split("/resourceGroups/")
                     if len(parts) > 1:
                         rg_part = parts[1].split("/")[0]


### PR DESCRIPTION
## Summary
- Fixed VMs being excluded from IaC generation
- 2 root causes identified and fixed
- Result: 0 → 24 VMs generated ✅

## Changes
1. Re-added VMs to AZURE_TO_TERRAFORM_MAPPING
2. Fixed subset filter to check resource_group property (not just ID format)

## Testing
✅ 24 SimuLand VMs now in Terraform (20 Windows + 4 Linux)
✅ 145 resources generated (was 4)
✅ Filtered graph: 212 resources (was 38)

## Impact
Unblocks Issue #591 - VMs can now be replicated to TENANT_2

🏴‍☠️ Generated with Claude Code