### PR TITLE
fix: Resolve YAML validation errors - duplicate description keys (Bug #632)

### DIFF
--- a/demos/walkthrough/scenarios/00_setup.yaml
+++ b/demos/walkthrough/scenarios/00_setup.yaml
@@ -30,7 +30,7 @@ steps:
 
   - description: "Verify dashboard loaded"
     action: "screenshot"
-    description: "Dashboard after authentication"
+    output: "Dashboard after authentication"
 
 assertions:
   - type: "element_visible"

--- a/demos/walkthrough/scenarios/01_status.yaml
+++ b/demos/walkthrough/scenarios/01_status.yaml
@@ -18,7 +18,7 @@ steps:
 
   - description: "Capture status overview"
     action: "screenshot"
-    description: "Status dashboard overview"
+    output: "Status dashboard overview"
 
   - description: "Check system health"
     action: "wait"
@@ -33,7 +33,7 @@ steps:
 
   - description: "Capture metrics view"
     action: "screenshot"
-    description: "System metrics display"
+    output: "System metrics display"
 
   - description: "Check for error indicators"
     action: "evaluate"
@@ -48,7 +48,7 @@ steps:
 
   - description: "Capture connection status"
     action: "screenshot"
-    description: "Connection and service status"
+    output: "Connection and service status"
 
 assertions:
   - type: "element_visible"

--- a/demos/walkthrough/scenarios/02_config.yaml
+++ b/demos/walkthrough/scenarios/02_config.yaml
@@ -18,7 +18,7 @@ steps:
 
   - description: "Capture configuration overview"
     action: "screenshot"
-    description: "Configuration settings overview"
+    output: "Configuration settings overview"
 
   - description: "Expand Azure settings"
     action: "click"
@@ -33,7 +33,7 @@ steps:
 
   - description: "Capture Azure settings"
     action: "screenshot"
-    description: "Azure tenant configuration"
+    output: "Azure tenant configuration"
 
   - description: "Expand scan settings"
     action: "click"
@@ -54,7 +54,7 @@ steps:
 
   - description: "Capture advanced settings"
     action: "screenshot"
-    description: "Advanced configuration options"
+    output: "Advanced configuration options"
 
   - description: "Test save configuration"
     action: "click"

--- a/demos/walkthrough/scenarios/04_visualize.yaml
+++ b/demos/walkthrough/scenarios/04_visualize.yaml
@@ -23,7 +23,7 @@ steps:
 
   - description: "Capture initial graph view"
     action: "screenshot"
-    description: "Initial graph visualization"
+    output: "Initial graph visualization"
 
   - description: "Open filter panel"
     action: "click"
@@ -45,7 +45,7 @@ steps:
 
   - description: "Capture filtered view"
     action: "screenshot"
-    description: "Filtered resource view"
+    output: "Filtered resource view"
 
   - description: "Reset zoom"
     action: "click"
@@ -81,7 +81,7 @@ steps:
 
   - description: "Capture node details"
     action: "screenshot"
-    description: "Node details panel"
+    output: "Node details panel"
 
   - description: "Toggle layout"
     action: "click"
@@ -91,7 +91,7 @@ steps:
 
   - description: "Capture alternative layout"
     action: "screenshot"
-    description: "Alternative graph layout"
+    output: "Alternative graph layout"
 
   - description: "Export graph"
     action: "click"

--- a/demos/walkthrough/scenarios/05_generate_spec.yaml
+++ b/demos/walkthrough/scenarios/05_generate_spec.yaml
@@ -18,7 +18,7 @@ steps:
 
   - description: "Capture spec generator interface"
     action: "screenshot"
-    description: "Specification generator ready"
+    output: "Specification generator ready"
 
   - description: "Select specification format"
     action: "select"
@@ -40,7 +40,7 @@ steps:
 
   - description: "Capture spec configuration"
     action: "screenshot"
-    description: "Spec generation configured"
+    output: "Spec generation configured"
 
   - description: "Generate specification"
     action: "click"
@@ -54,7 +54,7 @@ steps:
 
   - description: "Capture generated spec"
     action: "screenshot"
-    description: "Generated specification"
+    output: "Generated specification"
 
   - description: "Expand spec sections"
     action: "click"
@@ -69,7 +69,7 @@ steps:
 
   - description: "Capture detailed spec"
     action: "screenshot"
-    description: "Detailed specification view"
+    output: "Detailed specification view"
 
   - description: "Copy spec to clipboard"
     action: "click"

--- a/demos/walkthrough/scenarios/08_agent_mode.yaml
+++ b/demos/walkthrough/scenarios/08_agent_mode.yaml
@@ -18,7 +18,7 @@ steps:
 
   - description: "Capture agent interface"
     action: "screenshot"
-    description: "Agent mode interface"
+    output: "Agent mode interface"
 
   - description: "Type initial query"
     action: "fill"
@@ -39,7 +39,7 @@ steps:
 
   - description: "Capture agent response"
     action: "screenshot"
-    description: "Agent query response"
+    output: "Agent query response"
 
   - description: "Ask for recommendations"
     action: "fill"
@@ -60,7 +60,7 @@ steps:
 
   - description: "Capture recommendations"
     action: "screenshot"
-    description: "Security recommendations from agent"
+    output: "Security recommendations from agent"
 
   - description: "Scroll chat history"
     action: "scroll"
@@ -87,7 +87,7 @@ steps:
 
   - description: "Capture agent settings"
     action: "screenshot"
-    description: "Agent configuration options"
+    output: "Agent configuration options"
 
   - description: "Export chat history"
     action: "click"

--- a/demos/walkthrough/scenarios/09_create_tenant.yaml
+++ b/demos/walkthrough/scenarios/09_create_tenant.yaml
@@ -18,7 +18,7 @@ steps:
 
   - description: "Capture create tenant interface"
     action: "screenshot"
-    description: "Tenant creation interface"
+    output: "Tenant creation interface"
 
   - description: "Enter tenant name"
     action: "fill"
@@ -51,7 +51,7 @@ steps:
 
   - description: "Capture tenant configuration"
     action: "screenshot"
-    description: "Tenant configuration complete"
+    output: "Tenant configuration complete"
 
   - description: "Validate configuration"
     action: "click"
@@ -67,7 +67,7 @@ steps:
 
   - description: "Capture tenant preview"
     action: "screenshot"
-    description: "Tenant creation preview"
+    output: "Tenant creation preview"
 
   - description: "Scroll to create button"
     action: "scroll"
@@ -87,7 +87,7 @@ steps:
 
   - description: "Capture creation progress"
     action: "screenshot"
-    description: "Tenant creation in progress"
+    output: "Tenant creation in progress"
 
   - description: "Check creation result"
     action: "wait"

--- a/demos/walkthrough/scenarios/11_logs.yaml
+++ b/demos/walkthrough/scenarios/11_logs.yaml
@@ -18,7 +18,7 @@ steps:
 
   - description: "Capture logs interface"
     action: "screenshot"
-    description: "Logs viewer interface"
+    output: "Logs viewer interface"
 
   - description: "Select log level filter"
     action: "select"
@@ -49,7 +49,7 @@ steps:
 
   - description: "Capture filtered logs"
     action: "screenshot"
-    description: "Filtered log entries"
+    output: "Filtered log entries"
 
   - description: "Expand log entry"
     action: "click"
@@ -59,7 +59,7 @@ steps:
 
   - description: "View log details"
     action: "screenshot"
-    description: "Detailed log information"
+    output: "Detailed log information"
 
   - description: "Toggle error logs"
     action: "click"
@@ -98,7 +98,7 @@ steps:
 
   - description: "Capture system metrics"
     action: "screenshot"
-    description: "System performance metrics"
+    output: "System performance metrics"
 
 assertions:
   - type: "element_visible"


### PR DESCRIPTION
## Summary

Fixes duplicate `description:` keys in 8 demo scenario YAML files that were causing pre-commit `check-yaml` hook failures.

## Changes

Changed second occurrence of `description:` to `output:` in screenshot actions across all affected files:

- ✅ demos/walkthrough/scenarios/00_setup.yaml
- ✅ demos/walkthrough/scenarios/01_status.yaml
- ✅ demos/walkthrough/scenarios/02_config.yaml
- ✅ demos/walkthrough/scenarios/04_visualize.yaml
- ✅ demos/walkthrough/scenarios/05_generate_spec.yaml  
- ✅ demos/walkthrough/scenarios/08_agent_mode.yaml
- ✅ demos/walkthrough/scenarios/09_create_tenant.yaml
- ✅ demos/walkthrough/scenarios/11_logs.yaml

## Pattern

**Before:**
```yaml
- description: "Verify dashboard loaded"
  action: "screenshot"
  description: "Dashboard after authentication"  # ❌ Duplicate key
```

**After:**
```yaml
- description: "Verify dashboard loaded"
  action: "screenshot"
  output: "Dashboard after authentication"  # ✅ Unique key
```

## Validation

All YAML files now parse correctly without duplicate key errors.

---

Fixes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)