### PR TITLE
fix: Prioritize target tenant ID for Key Vault cross-tenant deployments (Bug #605)

### DIFF
--- a/src/iac/emitters/terraform/handlers/keyvault/vault.py
+++ b/src/iac/emitters/terraform/handlers/keyvault/vault.py
@@ -67,8 +67,8 @@ class KeyVaultHandler(ResourceHandler):
         sku_name = sku.get("name", "standard") if isinstance(sku, dict) else "standard"
         config["sku_name"] = sku_name
 
-        # Tenant ID (required)
-        tenant_id = properties.get("tenantId") or context.target_tenant_id
+        # Tenant ID (required) - prioritize target tenant for cross-tenant deployments
+        tenant_id = context.target_tenant_id or properties.get("tenantId")
         if tenant_id:
             config["tenant_id"] = tenant_id
         else:


### PR DESCRIPTION
## Summary

Fixes Bug #605 - Key Vault handler now correctly uses target tenant ID for cross-tenant deployments.

## Problem

Key Vault resources were being deployed with source tenant ID instead of target tenant ID, causing all cross-tenant deployments involving Key Vaults to fail with authentication errors.

## Root Cause

Line 71 in `vault.py` prioritized:
```python
tenant_id = properties.get("tenantId") or context.target_tenant_id  # ❌ Wrong order
```

This gets the source tenant ID from properties FIRST, only using target tenant as fallback.

## Fix

Reversed the priority:
```python
tenant_id = context.target_tenant_id or properties.get("tenantId")  # ✅ Correct order
```

Now uses target tenant ID when specified (cross-tenant mode), falls back to source tenant ID for same-tenant deployments.

## Impact

- ✅ Enables cross-tenant Key Vault deployments
- ✅ Respects --target-tenant-id CLI parameter
- ✅ Maintains backward compatibility (same-tenant deployments unaffected)
- ✅ Consistent with other cross-tenant translation patterns

## Testing

Cross-tenant deployment scenario:
```bash
uv run atg generate-iac --target-tenant-id <TARGET> --format terraform
# Key Vaults now use TARGET tenant ID instead of SOURCE
```

---

Fixes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)