### PR TITLE
fix: Change split_by_community default to False to prevent IaC generation hangs (Bug #593)

### DIFF
--- a/src/iac/emitters/terraform_emitter.py
+++ b/src/iac/emitters/terraform_emitter.py
@@ -356,7 +356,7 @@ class TerraformEmitter(IaCEmitter):
         domain_name: Optional[str] = None,
         subscription_id: Optional[str] = None,
         comparison_result: Optional[Any] = None,
-        split_by_community: bool = True,  # Bug #112: Default to True for parallel deployment
+        split_by_community: bool = False,  # Bug #593: Default to False to prevent unlimited path traversal
     ) -> List[Path]:
         """Generate Terraform template from tenant graph.
 


### PR DESCRIPTION
## Summary

ONE-LINE FIX for Bug #593 - Prevents IaC generation from hanging on large resource graphs by changing community split default.

## Problem

IaC generation hangs indefinitely when processing 1,500+ resources, blocking all large-scale deployments including Issue #591 VM replication.

**Symptoms:**
- Process appears frozen at community split stage
- No progress updates
- Must force-kill the process
- Affects any IaC generation with large resource counts

## Root Cause

Line 359 in `terraform_emitter.py`:
```python
split_by_community: bool = True  # ❌ Expensive by default
```

This triggered unlimited path traversal on EVERY IaC generation, even when users didn't request community splitting.

## Fix

ONE LINE CHANGE:
```python
split_by_community: bool = False  # ✅ Opt-in for expensive operation
```

## Impact

**Performance:**
- ✅ No hang on large resource graphs
- ✅ IaC generation completes successfully
- ✅ Unblocks Issue #591 and other large deployments

**Functionality:**
- ✅ Community split still available via `--split-by-community` flag
- ✅ Users who need it can still enable explicitly
- ✅ Makes expensive operation opt-in instead of opt-out

## Testing

**Before (hangs):**
```bash
uv run atg generate-iac --tenant-id <TENANT> # Hangs at community split
```

**After (works):**
```bash
uv run atg generate-iac --tenant-id <TENANT> # Completes successfully
uv run atg generate-iac --tenant-id <TENANT> --split-by-community # Still works when explicitly requested
```

## Philosophy Alignment

✅ **Ruthless Simplicity**: Expensive operations should be opt-in
✅ **Fail-Fast**: Don't hide performance issues behind defaults

---

Fixes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)