### PR TITLE
fix: Normalize SKU casing for Key Vault and Log Analytics (Bug #596)

### DIFF
--- a/src/iac/emitters/terraform/handlers/keyvault/vault.py
+++ b/src/iac/emitters/terraform/handlers/keyvault/vault.py
@@ -62,10 +62,10 @@ class KeyVaultHandler(ResourceHandler):
 
         config = self.build_base_config(resource, resource_name_with_suffix)
 
-        # SKU (required)
+        # SKU (required) - Bug #596: normalize to lowercase for Terraform
         sku = properties.get("sku", {})
         sku_name = sku.get("name", "standard") if isinstance(sku, dict) else "standard"
-        config["sku_name"] = sku_name
+        config["sku_name"] = sku_name.lower() if isinstance(sku_name, str) else "standard"
 
         # Tenant ID (required)
         tenant_id = properties.get("tenantId") or context.target_tenant_id

--- a/src/iac/emitters/terraform/handlers/monitoring/log_analytics.py
+++ b/src/iac/emitters/terraform/handlers/monitoring/log_analytics.py
@@ -42,10 +42,18 @@ class LogAnalyticsWorkspaceHandler(ResourceHandler):
 
         config = self.build_base_config(resource)
 
-        # SKU
+        # SKU - Bug #596: Log Analytics SKU must be PerGB2018 (mixed case) not pergb2018
         sku = properties.get("sku", {})
         if sku and "name" in sku:
-            config["sku"] = sku["name"]
+            sku_name = sku["name"]
+            # Normalize common SKU values to Terraform-expected casing
+            sku_normalized = {
+                "pergb2018": "PerGB2018",
+                "free": "Free",
+                "standalone": "Standalone",
+                "premium": "Premium",
+            }
+            config["sku"] = sku_normalized.get(sku_name.lower() if isinstance(sku_name, str) else "", sku_name)
 
         # Retention
         retention = properties.get("retentionInDays")


### PR DESCRIPTION
## Summary

Fixes Bug #596 - Normalizes SKU casing to match Terraform provider requirements, eliminating validation errors.

## Problems Fixed

**1. Key Vault SKU:**
- Azure returns: `Standard` (capitalized)
- Terraform expects: `standard` (lowercase)
- Error: Invalid SKU value

**2. Log Analytics SKU:**
- Azure returns: `pergb2018` (lowercase)
- Terraform expects: `PerGB2018` (mixed case)
- Error: Invalid SKU value

## Fixes

### Key Vault Handler (vault.py)

**Before:**
```python
sku_name = sku.get('name', 'standard')
config['sku_name'] = sku_name  # ❌ Uses Azure casing
```

**After:**
```python
sku_name = sku.get('name', 'standard')
config['sku_name'] = sku_name.lower()  # ✅ Normalized to lowercase
```

### Log Analytics Handler (log_analytics.py)

**Before:**
```python
config['sku'] = sku['name']  # ❌ Uses Azure casing directly
```

**After:**
```python
sku_normalized = {
    'pergb2018': 'PerGB2018',
    'free': 'Free',
    'standalone': 'Standalone',
    'premium': 'Premium',
}
config['sku'] = sku_normalized.get(sku_name.lower(), sku_name)  # ✅ Normalized
```

## Impact

- ✅ Eliminates Terraform validation errors
- ✅ `terraform plan` succeeds without SKU errors
- ✅ Enables deployment to TENANT_2
- ✅ Unblocks Issue #591 VM replication

## Testing

**Before (validation errors):**
```bash
terraform validate ./iac_output/
# Error: Invalid value for sku_name: 'Standard'
# Error: Invalid value for sku: 'pergb2018'
```

**After (passes):**
```bash
terraform validate ./iac_output/
# Success! The configuration is valid.
```

---

Fixes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)