### PR TITLE
fix: Correct cryptography import - PBKDF2 should be PBKDF2HMAC

### DIFF
--- a/tests/e2e/auth_security/security_utils.py
+++ b/tests/e2e/auth_security/security_utils.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import jwt
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 
 class TokenValidator:
@@ -188,7 +188,7 @@ class EncryptionHelper:
         if salt is None:
             salt = secrets.token_bytes(32)
 
-        kdf = PBKDF2(
+        kdf = PBKDF2HMAC(
             algorithm=hashes.SHA256(),
             length=32,
             salt=salt,


### PR DESCRIPTION
## Summary

Fixes test import error that prevented 224 tests from being collected.

## Problem

Test collection failed with:
```
ImportError: cannot import name 'PBKDF2' from 'cryptography.hazmat.primitives.kdf.pbkdf2'
```

## Root Cause

Typo in import - the correct class name is `PBKDF2HMAC`, not `PBKDF2`.

## Fix

**Line 20:**
```python
from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC  # ✅ Correct
```

**Line 191:**
```python
kdf = PBKDF2HMAC(  # ✅ Correct usage
    algorithm=hashes.SHA256(),
    ...
)
```

## Impact

- ✅ All 224 tests can now be collected
- ✅ e2e/auth_security tests can run
- ✅ Test suite is functional

## Testing

```bash
pytest tests/e2e/auth_security/test_authentication.py -v
# Now imports successfully and runs tests
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)