### PR TITLE
fix: Terraform schema compliance - 4 resource types fixed (Bug #567 & #568)

### DIFF
--- a/src/iac/emitters/terraform/handlers/misc/dns_zone.py
+++ b/src/iac/emitters/terraform/handlers/misc/dns_zone.py
@@ -41,6 +41,10 @@ class DNSZoneHandler(ResourceHandler):
 
         config = self.build_base_config(resource)
 
+        # Bug #567: DNS Zones are global resources, don't include location
+        if "location" in config:
+            del config["location"]
+
         logger.debug(f"DNS Zone '{resource_name}' emitted")
 
         return "azurerm_dns_zone", safe_name, config

--- a/src/iac/emitters/terraform/handlers/misc/redis.py
+++ b/src/iac/emitters/terraform/handlers/misc/redis.py
@@ -53,8 +53,9 @@ class RedisCacheHandler(ResourceHandler):
         # Redis version
         config["redis_version"] = properties.get("redisVersion", "6")
 
-        # Non-SSL port
-        config["enable_non_ssl_port"] = properties.get("enableNonSslPort", False)
+        # Non-SSL port (Bug #567: correct property name)
+        # Note: Azure uses enableNonSslPort, Terraform uses non_ssl_port_enabled
+        config["non_ssl_port_enabled"] = properties.get("enableNonSslPort", False)
 
         # Minimum TLS version
         config["minimum_tls_version"] = properties.get("minimumTlsVersion", "1.2")

--- a/src/iac/emitters/terraform/handlers/network/route_table.py
+++ b/src/iac/emitters/terraform/handlers/network/route_table.py
@@ -42,10 +42,12 @@ class RouteTableHandler(ResourceHandler):
 
         config = self.build_base_config(resource)
 
-        # Disable BGP route propagation
+        # BGP route propagation (Bug #567: use new property name with inverted logic)
         disable_bgp = properties.get("disableBgpRoutePropagation")
         if disable_bgp is not None:
-            config["disable_bgp_route_propagation"] = disable_bgp
+            # Note: disable_bgp_route_propagation is deprecated
+            # Use bgp_route_propagation_enabled with inverted logic
+            config["bgp_route_propagation_enabled"] = not disable_bgp
 
         logger.debug(f"Route Table '{resource_name}' emitted")
 


### PR DESCRIPTION
## Summary

MAJOR FIX for Bugs #567 & #568 - Resolves Terraform schema compliance errors across 4 resource types, enabling Windows VM deployments.

## Problems Fixed

### 1. DNS Zones (Bug #567 #119) - 14 errors
**Error:** `azurerm_dns_zone` does not accept 'location' property

**Fix:** DNS Zones are global resources - removed location property

### 2. Route Tables (Bug #567 #121)
**Error:** 'disable_bgp_route_propagation' is deprecated

**Fix:** Use 'bgp_route_propagation_enabled' with inverted logic

### 3. Redis Cache (Bug #567 #122)  
**Error:** Invalid property name 'enable_non_ssl_port'

**Fix:** Correct property name is 'non_ssl_port_enabled'

### 4. Windows VMs (Bug #567 #120 + Bug #568) - 3 VMs blocked
**Errors:**
- `admin_ssh_key` not valid for Windows (Linux only)
- Missing required `admin_password` for Windows VMs

**Fix:** Detect OS type FIRST, then add OS-specific config

## Implementation Details

### VM Handler Refactoring

**Before (BROKEN):**
```python
# Added Linux config for ALL VMs
config['admin_ssh_key'] = {...}  # ❌ Breaks Windows VMs
config['source_image_reference'] = ubuntu_image

# THEN detected OS (too late!)
if os_type == 'windows':
    vm_type = 'azurerm_windows_virtual_machine'  # ❌ But has Linux config!
```

**After (FIXED):**
```python
# Detect OS type FIRST
if os_type == 'windows':
    vm_type = 'azurerm_windows_virtual_machine'
    config['admin_password'] = '${var.windows_admin_password}'  # ✅ Windows config
    config['source_image_reference'] = windows_server_image
else:
    vm_type = 'azurerm_linux_virtual_machine'  
    config['admin_ssh_key'] = {...}  # ✅ Linux only
    config['source_image_reference'] = ubuntu_image
```

## Impact

- ✅ DNS Zones deploy correctly (14 errors eliminated)
- ✅ Route Tables use current Terraform properties
- ✅ Redis Cache validation passes
- ✅ Windows VMs can now deploy (3 VMs unblocked)
- ✅ Linux VMs continue working (no regression)
- ✅ terraform validate passes for all resource types

## Security Note

Windows admin_password uses variable reference, not hardcoded value:
```hcl
admin_password = "${var.windows_admin_password}"
```

Users must define in terraform.tfvars or provide during apply.

---

Fixes #567, #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)