### PR TITLE
fix: Re-export Cypher helper functions for backward compatibility

### DIFF
--- a/src/services/scale_down_service.py
+++ b/src/services/scale_down_service.py
@@ -13,9 +13,21 @@ All existing imports will continue to work via the alias below.
 """
 
 from src.services.scale_down import ScaleDownOrchestrator
+from src.services.scale_down.exporters.neo4j_exporter import (
+    _escape_cypher_identifier,
+    _escape_cypher_string,
+    _is_safe_cypher_identifier,
+)
 from src.services.scale_down.quality_metrics import QualityMetrics
 
 # Backward compatibility alias
 ScaleDownService = ScaleDownOrchestrator
 
-__all__ = ["QualityMetrics", "ScaleDownOrchestrator", "ScaleDownService"]
+__all__ = [
+    "QualityMetrics",
+    "ScaleDownOrchestrator",
+    "ScaleDownService",
+    "_escape_cypher_identifier",
+    "_escape_cypher_string",
+    "_is_safe_cypher_identifier",
+]


### PR DESCRIPTION
## Summary

Fixes test import error by re-exporting Cypher security functions from the backward compatibility facade.

## Problem

Test collection failed with:
```
ImportError: cannot import name '_escape_cypher_identifier' from 'src.services.scale_down_service'
```

## Root Cause

Functions were refactored into `src/services/scale_down/exporters/neo4j_exporter.py` during modularization, but the backward compatibility facade in `scale_down_service.py` didn't re-export them.

Tests still use old imports:
```python
from src.services.scale_down_service import (
    _escape_cypher_identifier,
    _escape_cypher_string,
    _is_safe_cypher_identifier,
)
```

## Fix

Added re-exports to `scale_down_service.py`:
```python
from src.services.scale_down.exporters.neo4j_exporter import (
    _escape_cypher_identifier,
    _escape_cypher_string,
    _is_safe_cypher_identifier,
)

__all__ = [
    ...,
    '_escape_cypher_identifier',
    '_escape_cypher_string',
    '_is_safe_cypher_identifier',
]
```

## Impact

- ✅ Fixes test collection for `test_security_injection.py`
- ✅ Maintains backward compatibility
- ✅ Functions stay in proper modular location
- ✅ No breaking changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)