### PR TITLE
feat: Add AzureNameSanitizer to 7 handlers with globally unique types

### DIFF
--- a/src/iac/emitters/terraform/handlers/misc/data_factory.py
+++ b/src/iac/emitters/terraform/handlers/misc/data_factory.py
@@ -7,6 +7,7 @@ Emits: azurerm_data_factory
 import logging
 from typing import Any, ClassVar, Dict, Optional, Set, Tuple
 
+from src.services.azure_name_sanitizer import AzureNameSanitizer
 from ...base_handler import ResourceHandler
 from ...context import EmitterContext
 from .. import handler
@@ -30,6 +31,11 @@ class DataFactoryHandler(ResourceHandler):
         "azurerm_data_factory",
     }
 
+    def __init__(self):
+        """Initialize handler with Azure name sanitizer."""
+        super().__init__()
+        self.sanitizer = AzureNameSanitizer()
+
     def emit(
         self,
         resource: Dict[str, Any],
@@ -41,6 +47,32 @@ class DataFactoryHandler(ResourceHandler):
         properties = self.parse_properties(resource)
 
         config = self.build_base_config(resource)
+
+        # Data Factory names must be globally unique
+        # Sanitize using centralized Azure naming rules
+        abstracted_name = config["name"]
+        sanitized_name = self.sanitizer.sanitize(
+            abstracted_name, "Microsoft.DataFactory/factories"
+        )
+
+        # Add tenant-specific suffix for cross-tenant deployments
+        if (
+            context.target_tenant_id
+            and context.source_tenant_id != context.target_tenant_id
+        ):
+            # Add target tenant suffix (last 6 chars of tenant ID, alphanumeric only)
+            tenant_suffix = context.target_tenant_id[-6:].replace("-", "").lower()
+
+            # Truncate to fit (63 - 7 = 56 chars for sanitized name + dash)
+            if len(sanitized_name) > 56:
+                sanitized_name = sanitized_name[:56]
+
+            config["name"] = f"{sanitized_name}-{tenant_suffix}"
+            logger.info(
+                f"Cross-tenant deployment: Data Factory '{abstracted_name}' → '{config['name']}' (tenant suffix: {tenant_suffix})"
+            )
+        else:
+            config["name"] = sanitized_name
 
         # Public network access
         if properties.get("publicNetworkAccess"):

--- a/src/iac/emitters/terraform/handlers/misc/databricks.py
+++ b/src/iac/emitters/terraform/handlers/misc/databricks.py
@@ -7,6 +7,7 @@ Emits: azurerm_databricks_workspace
 import logging
 from typing import Any, ClassVar, Dict, Optional, Set, Tuple
 
+from src.services.azure_name_sanitizer import AzureNameSanitizer
 from ...base_handler import ResourceHandler
 from ...context import EmitterContext
 from .. import handler
@@ -30,6 +31,11 @@ class DatabricksWorkspaceHandler(ResourceHandler):
         "azurerm_databricks_workspace",
     }
 
+    def __init__(self):
+        """Initialize handler with Azure name sanitizer."""
+        super().__init__()
+        self.sanitizer = AzureNameSanitizer()
+
     def emit(
         self,
         resource: Dict[str, Any],
@@ -41,6 +47,32 @@ class DatabricksWorkspaceHandler(ResourceHandler):
         properties = self.parse_properties(resource)
 
         config = self.build_base_config(resource)
+
+        # Databricks Workspace names must be globally unique
+        # Sanitize using centralized Azure naming rules
+        abstracted_name = config["name"]
+        sanitized_name = self.sanitizer.sanitize(
+            abstracted_name, "Microsoft.Databricks/workspaces"
+        )
+
+        # Add tenant-specific suffix for cross-tenant deployments
+        if (
+            context.target_tenant_id
+            and context.source_tenant_id != context.target_tenant_id
+        ):
+            # Add target tenant suffix (last 6 chars of tenant ID, alphanumeric only)
+            tenant_suffix = context.target_tenant_id[-6:].replace("-", "").lower()
+
+            # Truncate to fit (64 - 7 = 57 chars for sanitized name + dash)
+            if len(sanitized_name) > 57:
+                sanitized_name = sanitized_name[:57]
+
+            config["name"] = f"{sanitized_name}-{tenant_suffix}"
+            logger.info(
+                f"Cross-tenant deployment: Databricks Workspace '{abstracted_name}' → '{config['name']}' (tenant suffix: {tenant_suffix})"
+            )
+        else:
+            config["name"] = sanitized_name
 
         # SKU
         sku = resource.get("sku", {})

--- a/src/iac/emitters/terraform/handlers/misc/eventhub.py
+++ b/src/iac/emitters/terraform/handlers/misc/eventhub.py
@@ -7,6 +7,7 @@ Emits: azurerm_eventhub_namespace, azurerm_eventhub
 import logging
 from typing import Any, ClassVar, Dict, Optional, Set, Tuple
 
+from src.services.azure_name_sanitizer import AzureNameSanitizer
 from ...base_handler import ResourceHandler
 from ...context import EmitterContext
 from .. import handler
@@ -30,6 +31,11 @@ class EventHubNamespaceHandler(ResourceHandler):
         "azurerm_eventhub_namespace",
     }
 
+    def __init__(self):
+        """Initialize handler with Azure name sanitizer."""
+        super().__init__()
+        self.sanitizer = AzureNameSanitizer()
+
     def emit(
         self,
         resource: Dict[str, Any],
@@ -41,6 +47,32 @@ class EventHubNamespaceHandler(ResourceHandler):
         properties = self.parse_properties(resource)
 
         config = self.build_base_config(resource)
+
+        # Event Hub Namespace names must be globally unique (*.servicebus.windows.net)
+        # Sanitize using centralized Azure naming rules
+        abstracted_name = config["name"]
+        sanitized_name = self.sanitizer.sanitize(
+            abstracted_name, "Microsoft.EventHub/namespaces"
+        )
+
+        # Add tenant-specific suffix for cross-tenant deployments
+        if (
+            context.target_tenant_id
+            and context.source_tenant_id != context.target_tenant_id
+        ):
+            # Add target tenant suffix (last 6 chars of tenant ID, alphanumeric only)
+            tenant_suffix = context.target_tenant_id[-6:].replace("-", "").lower()
+
+            # Truncate to fit (50 - 7 = 43 chars for sanitized name + dash)
+            if len(sanitized_name) > 43:
+                sanitized_name = sanitized_name[:43]
+
+            config["name"] = f"{sanitized_name}-{tenant_suffix}"
+            logger.info(
+                f"Cross-tenant deployment: Event Hub Namespace '{abstracted_name}' → '{config['name']}' (tenant suffix: {tenant_suffix})"
+            )
+        else:
+            config["name"] = sanitized_name
 
         # SKU
         sku = properties.get("sku", {})

--- a/src/iac/emitters/terraform/handlers/misc/search_service.py
+++ b/src/iac/emitters/terraform/handlers/misc/search_service.py
@@ -7,6 +7,7 @@ Emits: azurerm_search_service
 import logging
 from typing import Any, ClassVar, Dict, Optional, Set, Tuple
 
+from src.services.azure_name_sanitizer import AzureNameSanitizer
 from ...base_handler import ResourceHandler
 from ...context import EmitterContext
 from .. import handler
@@ -30,6 +31,11 @@ class SearchServiceHandler(ResourceHandler):
         "azurerm_search_service",
     }
 
+    def __init__(self):
+        """Initialize handler with Azure name sanitizer."""
+        super().__init__()
+        self.sanitizer = AzureNameSanitizer()
+
     def emit(
         self,
         resource: Dict[str, Any],
@@ -41,6 +47,32 @@ class SearchServiceHandler(ResourceHandler):
         properties = self.parse_properties(resource)
 
         config = self.build_base_config(resource)
+
+        # Search Service names must be globally unique (*.search.windows.net)
+        # Sanitize using centralized Azure naming rules
+        abstracted_name = config["name"]
+        sanitized_name = self.sanitizer.sanitize(
+            abstracted_name, "Microsoft.Search/searchServices"
+        )
+
+        # Add tenant-specific suffix for cross-tenant deployments
+        if (
+            context.target_tenant_id
+            and context.source_tenant_id != context.target_tenant_id
+        ):
+            # Add target tenant suffix (last 6 chars of tenant ID, alphanumeric only)
+            tenant_suffix = context.target_tenant_id[-6:].replace("-", "").lower()
+
+            # Truncate to fit (60 - 7 = 53 chars for sanitized name + dash)
+            if len(sanitized_name) > 53:
+                sanitized_name = sanitized_name[:53]
+
+            config["name"] = f"{sanitized_name}-{tenant_suffix}"
+            logger.info(
+                f"Cross-tenant deployment: Search Service '{abstracted_name}' → '{config['name']}' (tenant suffix: {tenant_suffix})"
+            )
+        else:
+            config["name"] = sanitized_name
 
         # SKU
         sku = resource.get("sku", {})

--- a/src/iac/emitters/terraform/handlers/ml/cognitive_services.py
+++ b/src/iac/emitters/terraform/handlers/ml/cognitive_services.py
@@ -7,6 +7,7 @@ Emits: azurerm_cognitive_account
 import logging
 from typing import Any, ClassVar, Dict, Optional, Set, Tuple
 
+from src.services.azure_name_sanitizer import AzureNameSanitizer
 from ...base_handler import ResourceHandler
 from ...context import EmitterContext
 from .. import handler
@@ -30,6 +31,11 @@ class CognitiveServicesHandler(ResourceHandler):
         "azurerm_cognitive_account",
     }
 
+    def __init__(self):
+        """Initialize handler with Azure name sanitizer."""
+        super().__init__()
+        self.sanitizer = AzureNameSanitizer()
+
     def emit(
         self,
         resource: Dict[str, Any],
@@ -41,6 +47,32 @@ class CognitiveServicesHandler(ResourceHandler):
         properties = self.parse_properties(resource)
 
         config = self.build_base_config(resource)
+
+        # Cognitive Services names must be globally unique
+        # Sanitize using centralized Azure naming rules
+        abstracted_name = config["name"]
+        sanitized_name = self.sanitizer.sanitize(
+            abstracted_name, "Microsoft.CognitiveServices/accounts"
+        )
+
+        # Add tenant-specific suffix for cross-tenant deployments
+        if (
+            context.target_tenant_id
+            and context.source_tenant_id != context.target_tenant_id
+        ):
+            # Add target tenant suffix (last 6 chars of tenant ID, alphanumeric only)
+            tenant_suffix = context.target_tenant_id[-6:].replace("-", "").lower()
+
+            # Truncate to fit (64 - 7 = 57 chars for sanitized name + dash)
+            if len(sanitized_name) > 57:
+                sanitized_name = sanitized_name[:57]
+
+            config["name"] = f"{sanitized_name}-{tenant_suffix}"
+            logger.info(
+                f"Cross-tenant deployment: Cognitive Services '{abstracted_name}' → '{config['name']}' (tenant suffix: {tenant_suffix})"
+            )
+        else:
+            config["name"] = sanitized_name
 
         # Kind (required)
         kind = properties.get("kind", resource.get("kind", "OpenAI"))


### PR DESCRIPTION
## Summary

Adds AzureNameSanitizer integration to 7 handlers managing globally unique Azure resource types.

## Handlers Updated

1. redis.py - Microsoft.Cache/redis
2. eventhub.py - Microsoft.EventHub/namespaces
3. servicebus.py - Microsoft.ServiceBus/namespaces
4. cognitive_services.py - Microsoft.CognitiveServices/accounts
5. search_service.py - Microsoft.Search/searchServices
6. databricks.py - Microsoft.Databricks/workspaces
7. data_factory.py - Microsoft.DataFactory/factories

## Implementation

- Added AzureNameSanitizer to all 7 handlers
- Implemented cross-tenant suffix logic
- Proper length truncation for each type
- +224 lines of integration code

## Result

12 of 34 globally unique types now have handler integration (35%)

Closes #666 | Completes PR #660, #663, #665