### PR TITLE
fix: Electron app compatibility for WSL and cross-platform support

### DIFF
--- a/spa/backend/src/server.ts
+++ b/spa/backend/src/server.ts
@@ -51,7 +51,16 @@ const io = new SocketIOServer(httpServer, {
           socketCorsOrigins.includes('*') ||
           origin.match(/^http:\/\/(localhost|127\.0\.0\.1):\d+$/)) {
         callback(null, true);
-      } else {
+      }
+      // Allow file:// protocol for Electron desktop app
+      // SECURITY NOTE: This permits file:// origins which are used by Electron.
+      // Authentication middleware still enforces token-based auth for all connections.
+      // In production on shared systems, ensure auth tokens are properly secured.
+      else if (origin.startsWith('file://')) {
+        logger.info(`Allowing file:// origin for Electron app: ${origin}`);
+        callback(null, true);
+      }
+      else {
         logger.warn(`Socket.IO CORS: Blocked connection from origin: ${origin}`);
         callback(new Error('Not allowed by CORS'));
       }

--- a/spa/package.json
+++ b/spa/package.json
@@ -3,7 +3,7 @@
   "productName": "Azure Tenant Grapher",
   "version": "1.0.0",
   "description": "Graph visualization and management tool for Azure tenants",
-  "main": "dist/main/index.js",
+  "main": "dist/main/main/index.js",
   "scripts": {
     "dev": "concurrently -k \"npm run dev:main\" \"npm run dev:renderer\" \"npm run dev:backend\"",
     "dev:main": "tsc -w -p main/tsconfig.json",


### PR DESCRIPTION
Fixes Electron desktop app failing to start in WSL due to path resolution errors from nested TypeScript build output structure.

Changes:
- package.json: Update entry point to dist/main/main/index.js
- main/index.ts: Fix 8 path calculations for nested build directory
- main/index.ts: Add platform-specific Python venv path (Windows vs Unix)
- main/index.ts: Add Python path validation with helpful error messages
- server.ts: Add CORS support for file:// protocol (Electron)
- server.ts: Add security logging for file:// connections

Root Cause:
TypeScript compiler with rootDir=".." creates nested output at dist/main/main/index.js instead of dist/main/index.js, requiring all relative paths to add one extra directory level (../../../.. vs ../../..).

Cross-Platform Support:
- Windows: .venv/Scripts/python.exe
- Unix (macOS/Linux/WSL): .venv/bin/python

Security:
- file:// CORS documented with security notes
- Authentication middleware still enforces token-based auth
- Added logging for file:// origin connections

Testing:
✅ WSL: Electron launches successfully
✅ Entry point verified at correct path
✅ MCP server starts with platform-specific Python path ✅ Backend WebSocket connections work
✅ Neo4j connects properly
✅ Web UI unaffected (still works at localhost:5173)