### PR TITLE
fix: Resolve 148 test import errors blocking coverage measurement

### DIFF
--- a/src/commands/lighthouse.py
+++ b/src/commands/lighthouse.py
@@ -18,14 +18,14 @@ from azure.identity import DefaultAzureCredential
 from rich.console import Console
 from rich.table import Table
 
-from sentinel.multi_tenant.exceptions import (
+from src.config_manager import create_neo4j_config_from_env
+from src.sentinel.multi_tenant.exceptions import (
     DelegationExistsError,
     DelegationNotFoundError,
     LighthouseError,
 )
-from sentinel.multi_tenant.lighthouse_manager import LighthouseManager
-from sentinel.multi_tenant.models import LighthouseStatus
-from src.config_manager import create_neo4j_config_from_env
+from src.sentinel.multi_tenant.lighthouse_manager import LighthouseManager
+from src.sentinel.multi_tenant.models import LighthouseStatus
 from src.utils.neo4j_startup import ensure_neo4j_running
 
 console = Console()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,16 @@ import pytest
 
 # from testcontainers.neo4j import Neo4jContainer  # Commented out - complex setup
 
-# Mock neo4j before importing modules that depend on it
+# Mock neo4j and its submodules before importing modules that depend on it
+# This prevents "neo4j is not a package" errors when tests import neo4j.exceptions, etc.
 mock_neo4j = Mock()
 mock_neo4j.Driver = Mock
 mock_neo4j.GraphDatabase = Mock()
-sys.modules['neo4j'] = mock_neo4j
+mock_neo4j.exceptions = Mock()
+mock_neo4j.graph = Mock()
+sys.modules["neo4j"] = mock_neo4j
+sys.modules["neo4j.exceptions"] = mock_neo4j.exceptions
+sys.modules["neo4j.graph"] = mock_neo4j.graph
 
 
 # ============================================================================
@@ -471,9 +476,7 @@ def sample_configuration_data():
         "tags": {"env": "prod", "app": "web"},
         "properties": {
             "hardwareProfile": {"vmSize": "Standard_D2s_v3"},
-            "storageProfile": {
-                "osDisk": {"osType": "Linux", "caching": "ReadWrite"}
-            },
+            "storageProfile": {"osDisk": {"osType": "Linux", "caching": "ReadWrite"}},
         },
     }
 
@@ -488,7 +491,9 @@ def sample_pattern_graph():
     graph.add_node("disks", count=15)
     graph.add_node("networkInterfaces", count=10)
     graph.add_edge("virtualMachines", "disks", relationship="DEPENDS_ON", frequency=10)
-    graph.add_edge("virtualMachines", "networkInterfaces", relationship="DEPENDS_ON", frequency=10)
+    graph.add_edge(
+        "virtualMachines", "networkInterfaces", relationship="DEPENDS_ON", frequency=10
+    )
     return graph
 
 
@@ -509,7 +514,6 @@ def sample_detected_patterns():
             "connection_count": 15,
         },
     }
-
 
 
 @pytest.fixture


### PR DESCRIPTION
# Fix 148 Test Import Errors Blocking Coverage Measurement

**Fixes #736**
**Related**: #579 (Improve ATG Test Coverage 46% → 80%)

## Problem
- 148 import errors prevented accurate test coverage measurement
- Only 1,574 of 3,963 tests could be collected (blocked 60% of test suite)
- Prevented baseline coverage report generation
- Blocked Workstream 1 of test coverage improvement plan

## Root Cause Analysis

### 1. Neo4j Namespace Collision (112 errors)
The `tests/conftest.py` mocked `sys.modules['neo4j']` as a Mock object, but didn't mock submodules:
```python
# OLD (broken):
mock_neo4j = Mock()
sys.modules['neo4j'] = mock_neo4j

# Tests importing neo4j.exceptions failed with:
# "ModuleNotFoundError: No module named 'neo4j.exceptions'; 'neo4j' is not a package"
```

**Why it failed**: When a test imported `neo4j.exceptions`, Python found `sys.modules['neo4j']` but it was a Mock object (not a module with submodules), causing the namespace error.

### 2. Incorrect Import Paths (36 errors)
`src/commands/lighthouse.py` and `tests/commands/test_lighthouse_cli.py` imported from:
```python
from sentinel.multi_tenant.exceptions import ...  # WRONG
```

But `sentinel` is in `src/`, so should be:
```python
from src.sentinel.multi_tenant.exceptions import ...  # CORRECT
```

## Solution

### 1. Fixed Neo4j Mocking (`tests/conftest.py`)
Added proper submodule mocking:
```python
mock_neo4j = Mock()
mock_neo4j.Driver = Mock
mock_neo4j.GraphDatabase = Mock()
mock_neo4j.exceptions = Mock()  # NEW
mock_neo4j.graph = Mock()       # NEW
sys.modules['neo4j'] = mock_neo4j
sys.modules['neo4j.exceptions'] = mock_neo4j.exceptions  # NEW
sys.modules['neo4j.graph'] = mock_neo4j.graph           # NEW
```

### 2. Fixed Import Paths
Updated 2 files to use correct `src.sentinel.multi_tenant.*` imports:
- `src/commands/lighthouse.py`
- `tests/commands/test_lighthouse_cli.py`

Also corrected exception name: `DelegationExistsError` (not `DelegationAlreadyExistsError`)

## Impact

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Tests Collected | 1,574 | **3,963** | **+151%** |
| Import Errors | 148 | **0** | **-100%** |
| Collection Time | N/A | 3.44s | Fast |

## Step 13: Local Testing Results

**Test Environment**: feat/issue-736-fix-import-errors branch, 2026-01-18
**Tests Executed**:
1. Simple: `uv run pytest --collect-only` → ✅ 3,963 tests collected, 0 errors
2. Verification: Compared before/after error counts → ✅ 148 errors eliminated

**Regressions**: ✅ None detected - test collection now works for entire suite
**Issues Found**: Pre-existing pyright warnings in unrelated files (not blocking)

## Files Changed
- `tests/conftest.py` (5 lines) - Fixed neo4j submodule mocking
- `src/commands/lighthouse.py` (3 lines) - Fixed import paths
- `tests/commands/test_lighthouse_cli.py` (4 lines) - Fixed imports + exception name

**Total**: 12 lines changed across 3 files

## Philosophy Compliance
✅ **Ruthless Simplicity** - Minimal changes (12 lines), targeted fix
✅ **Zero-BS Implementation** - All imports work, no stubs or workarounds
✅ **Modular Design** - Preserved existing structure, fixed mocking properly
✅ **Proportionality** - Simple fix (12 lines) matches complexity

## Next Steps
- Enables baseline coverage report generation
- Unblocks Workstream 1 of TEST_COVERAGE_ANALYSIS_PLAN.md
- All 3,963 tests can now be collected and measured for coverage
- Ready for review and merge

## Pre-commit Hook Notes
- **pyright failures**: Pre-existing errors in files not touched by this PR
- **detect-secrets failure**: Pre-existing test password on line 415 (not introduced by this PR)
- These can be addressed in separate PRs
