### PR TITLE
fix(terraform): Add Key Vault secret support for Windows VM passwords (Issue #568)

### DIFF
--- a/src/iac/emitters/terraform/context.py
+++ b/src/iac/emitters/terraform/context.py
@@ -107,6 +107,38 @@ class EmitterContext:
             self.terraform_config["resource"][resource_type] = {}
         self.terraform_config["resource"][resource_type][name] = config
 
+    def add_data_source(
+        self,
+        data_type: str,
+        name: str,
+        config: Dict[str, Any],
+    ) -> None:
+        """Add a data source to terraform config.
+
+        Data sources allow referencing existing Azure resources
+        (e.g., Key Vault secrets, existing VNets).
+
+        Args:
+            data_type: Terraform data source type (e.g., "azurerm_key_vault_secret")
+            name: Data source name
+            config: Data source configuration dict
+
+        Example:
+            context.add_data_source(
+                "azurerm_key_vault_secret",
+                "vm_admin_password",
+                {
+                    "name": "vm-admin-password",
+                    "key_vault_id": "${data.azurerm_key_vault.main.id}",
+                },
+            )
+        """
+        if "data" not in self.terraform_config:
+            self.terraform_config["data"] = {}
+        if data_type not in self.terraform_config["data"]:
+            self.terraform_config["data"][data_type] = {}
+        self.terraform_config["data"][data_type][name] = config
+
     def get_effective_subscription_id(self, resource: Dict[str, Any]) -> str:
         """Get the subscription ID to use for resource construction.
 


### PR DESCRIPTION
## Problem
Windows VMs cannot be deployed because terraform config is missing required `admin_password` argument (Issue #568).

**Error**:
```
Error: Missing required argument
'admin_username': all of admin_password,admin_username must be specified
```

**Impact**: Blocks 3 VMs from deployment

## Solution (Option A - Key Vault References)
Modified Windows VM handler to use Azure Key Vault secret references instead of `random_password` provider.

## Changes
1. **EmitterContext** (`src/iac/emitters/terraform/context.py`):
   - Added `add_data_source()` method for creating Terraform data sources
   - Follows same pattern as `add_helper_resource()`

2. **VirtualMachineHandler** (`src/iac/emitters/terraform/handlers/compute/virtual_machine.py`):
   - Replaced `random_password` helper resource with Key Vault data source
   - Added comprehensive comments documenting Key Vault setup prerequisites
   - Updated TERRAFORM_TYPES constant to include `data.azurerm_key_vault_secret`

## Security
- ✅ Passwords are NO LONGER generated in Terraform state
- ✅ Users must create Key Vault secrets before `terraform apply`
- ✅ No hardcoded passwords

## Prerequisites for Users
Before using generated Terraform:
1. Create Key Vault: `az keyvault create --name <vault-name> --resource-group <rg-name> --location <location>`
2. Set password secret: `az keyvault secret set --vault-name <vault-name> --name <secret-name> --value <password>`
3. Ensure Terraform has Key Vault access (IAM role: Key Vault Secrets User)
4. Define `var.key_vault_id` in Terraform variables

## Files Changed
- `src/iac/emitters/terraform/context.py` (+32 lines)
- `src/iac/emitters/terraform/handlers/compute/virtual_machine.py` (+43/-13 lines)

Fixes #568

---

🧹 **Clean PR**: This is a clean recreation of PR #754, containing ONLY the Windows VM password fix changes without unrelated commits.