### PR TITLE
fix(spa): Fix Generate Spec tab file generation (Issues #687, #688)

### DIFF
--- a/spa/backend/src/security/input-validator.ts
+++ b/spa/backend/src/security/input-validator.ts
@@ -48,6 +48,7 @@ const ALLOWED_ARGS = new Set([
   '--max-llm-threads',
   '--max-build-threads',
   '--resource-limit',
+  '--limit',
   '--rebuild-edges',
   '--visualize',
   '--visualize-only',

--- a/spa/main/process-manager-secure.ts
+++ b/spa/main/process-manager-secure.ts
@@ -68,11 +68,18 @@ export class SecureProcessManager extends EventEmitter {
     }
 
     const id = uuidv4();
-    const pythonPath = process.env.PYTHON_PATH || 'python3';
-    const cliPath = path.resolve(__dirname, '../../../scripts/cli.py');
+    const projectRoot = path.resolve(__dirname, '../../../..');
+
+    // Use virtual environment Python instead of system Python
+    const pythonPath = process.env.PYTHON_PATH || (
+      process.platform === 'win32'
+        ? path.join(projectRoot, '.venv', 'Scripts', 'python.exe')
+        : path.join(projectRoot, '.venv', 'bin', 'python')
+    );
+
+    const cliPath = path.resolve(__dirname, '../../../../scripts/cli.py');
 
     // Verify CLI path is within project
-    const projectRoot = path.resolve(__dirname, '../../..');
     if (!cliPath.startsWith(projectRoot)) {
       throw new Error('CLI path outside project directory');
     }

--- a/spa/main/process-manager.ts
+++ b/spa/main/process-manager.ts
@@ -37,8 +37,16 @@ export class ProcessManager extends EventEmitter {
     }
 
     const id = uuidv4();
-    const pythonPath = process.env.PYTHON_PATH || 'python3';
-    const cliPath = path.resolve(__dirname, '../../../scripts/cli.py');
+    const projectRoot = path.resolve(__dirname, '../../../..');
+
+    // Use virtual environment Python instead of system Python
+    const pythonPath = process.env.PYTHON_PATH || (
+      process.platform === 'win32'
+        ? path.join(projectRoot, '.venv', 'Scripts', 'python.exe')
+        : path.join(projectRoot, '.venv', 'bin', 'python')
+    );
+
+    const cliPath = path.resolve(__dirname, '../../../../scripts/cli.py');
 
     console.log('[ProcessManager] Executing command:', command, 'with args:', args);
     console.log('[ProcessManager] Python path:', pythonPath);
@@ -49,11 +57,11 @@ export class ProcessManager extends EventEmitter {
 
     // Never use shell: true to prevent command injection
     const childProcess = spawn(pythonPath, fullArgs, {
-      cwd: path.resolve(__dirname, '../../..'),
+      cwd: projectRoot,
       shell: false, // Explicitly disable shell execution
       env: {
         ...process.env,
-        PYTHONPATH: path.resolve(__dirname, '../../..'),
+        PYTHONPATH: projectRoot,
         PYTHONUNBUFFERED: '1', // Force Python to flush output immediately
       },
     });

--- a/spa/renderer/src/components/tabs/GenerateSpecTab.tsx
+++ b/spa/renderer/src/components/tabs/GenerateSpecTab.tsx
@@ -189,6 +189,7 @@ const GenerateSpecTab: React.FC = () => {
             value={generatedSpec || '// Specification will appear here after generation'}
             language={outputFormat === 'json' ? 'json' : 'markdown'}
             theme="vs-dark"
+            loading={null}
             options={{
               readOnly: true,
               minimap: { enabled: false },


### PR DESCRIPTION
## Summary

Fixed path resolution issues in the Electron SPA that prevented the Generate Spec tab from successfully executing the CLI command to generate tenant specification files.

### Issues Fixed
- **Issue #687**: Generate Spec tab not generating files due to incorrect path resolution
- **Issue #688**: Related CLI execution failures in SPA

### Changes Made

1. **Path Resolution Fix** (`process-manager.ts`, `process-manager-secure.ts`)
   - Changed CLI path from `../../../scripts/cli.py` to `../../../../scripts/cli.py`
   - Calculate `projectRoot` as 4 levels up from `__dirname` (from compiled `dist/main/main/`)
   - Use virtual environment Python (`.venv/bin/python`) instead of system `python3`
   - Use `projectRoot` for `cwd` and `PYTHONPATH`

2. **Input Validation** (`input-validator.ts`)
   - Added `--limit` flag to `ALLOWED_ARGS` set to allow resource limiting

3. **UI Improvement** (`GenerateSpecTab.tsx`)
   - Set Monaco editor `loading={null}` to hide "Loading..." text

### Technical Details

**Before:**
```typescript
const pythonPath = process.env.PYTHON_PATH || 'python3';
const cliPath = path.resolve(__dirname, '../../../scripts/cli.py');
// Result: /home/.../ATG_WSL/spa/scripts/cli.py ❌ (doesn't exist)
```

**After:**
```typescript
const projectRoot = path.resolve(__dirname, '../../../..');
const pythonPath = path.join(projectRoot, '.venv/bin/python');
const cliPath = path.resolve(__dirname, '../../../../scripts/cli.py');
// Result: /home/.../ATG_WSL/scripts/cli.py ✅ (correct!)
```

### Testing

✅ **Manual Testing Completed:**
- Started Electron app
- Navigated to Generate Spec tab
- Clicked "Generate Spec" with limit=3
- **Result**: File successfully generated at `outputs/20260118_192938_tenant_spec.md`
- Console shows: `INFO:src.tenant_spec_generator:Specification written to outputs/...`
- No errors, exit code 0

### Impact

- Generate Spec tab now works correctly in the SPA
- Users can generate tenant specifications from the GUI
- Files are created in the correct `outputs/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)