### PR TITLE
Fix: Change logger.debug to logger.warning for child resource discovery failures

### DIFF
--- a/src/services/azure_discovery_service.py
+++ b/src/services/azure_discovery_service.py
@@ -715,7 +715,7 @@ class AzureDiscoveryService:
                             child_resources.append(subnet_dict)
 
                     except Exception as e:
-                        logger.debug(
+                        logger.warning(
                             str(f"Failed to fetch subnets for {vnet_name}: {e}")
                         )
 
@@ -767,7 +767,7 @@ class AzureDiscoveryService:
                             child_resources.append(runbook_dict)
 
                     except Exception as e:
-                        logger.debug(
+                        logger.warning(
                             f"Failed to fetch runbooks for {account_name}: {e}"
                         )
 
@@ -820,7 +820,7 @@ class AzureDiscoveryService:
                             child_resources.append(link_dict)
 
                     except Exception as e:
-                        logger.debug(
+                        logger.warning(
                             str(f"Failed to fetch DNS links for {zone_name}: {e}")
                         )
 
@@ -875,7 +875,7 @@ class AzureDiscoveryService:
                             child_resources.append(ext_dict)
 
                     except Exception as e:
-                        logger.debug(
+                        logger.warning(
                             f"Failed to fetch VM extensions for {vm_name}: {e}"
                         )
 
@@ -932,7 +932,7 @@ class AzureDiscoveryService:
                             child_resources.append(db_dict)
 
                     except Exception as e:
-                        logger.debug(
+                        logger.warning(
                             f"Failed to fetch databases for {server_name}: {e}"
                         )
 
@@ -999,7 +999,7 @@ class AzureDiscoveryService:
                             pass
 
                     except Exception as e:
-                        logger.debug(
+                        logger.warning(
                             f"Failed to fetch PostgreSQL configs for {server_name}: {e}"
                         )
 
@@ -1059,7 +1059,7 @@ class AzureDiscoveryService:
                             child_resources.append(webhook_dict)
 
                     except Exception as e:
-                        logger.debug(
+                        logger.warning(
                             f"Failed to fetch webhooks for {registry_name}: {e}"
                         )
 


### PR DESCRIPTION
## Problem

Child resource discovery failures (VNets/Subnets, Automation Runbooks, DNS Links, VM Extensions, SQL Databases, PostgreSQL Configs, Container Registry Webhooks) were logged at DEBUG level, making them invisible to users.

## Solution

Changed 7 child resource discovery failure locations from `logger.debug()` to `logger.warning()`:
- Subnets (line 718)
- Runbooks (line 770)
- DNS Links (line 823)
- VM Extensions (line 878)
- SQL Databases (line 935)
- PostgreSQL Configs (line 1002)
- Container Registry Webhooks (line 1062)

## Impact

Users will now see warnings when child resource discovery fails, making Azure API issues visible instead of silent.

## Step 13: Local Testing Results

**Test Environment**: feat/issue-776-child-discovery-logging branch, 2026-01-19

**Tests Executed**:
1. Simple: Code verification → All 7 logger.debug changed to logger.warning ✅
2. Complex: Manual code review → Clean fix, no side effects ✅

**Regressions**: Manual review → ✅ None detected (trivial logging level change)

**Issues Found**: None

## Philosophy Compliance

- ✅ Ruthless simplicity: Minimal change (7 lines), maximum impact
- ✅ Zero-BS implementation: Real fix, no stubs or placeholders
- ✅ Proportional change: 7 lines changed, appropriate for logging level fix

Fixes #776