### PR TITLE
fix: Deploy command now respects AZURE_TENANT_ID from .env (Issue #779)

### DIFF
--- a/tests/commands/test_deploy_env_fallback.py
+++ b/tests/commands/test_deploy_env_fallback.py
@@ -1,0 +1,137 @@
+"""Tests for deploy command AZURE_TENANT_ID .env fallback (Issue #779).
+
+This test verifies that the deploy command respects AZURE_TENANT_ID from .env
+like all other commands (scan, spec, mcp).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from src.commands.deploy import deploy_command
+
+
+class TestDeployEnvFallback:
+    """Test deploy command .env fallback for AZURE_TENANT_ID."""
+
+    @pytest.fixture
+    def mock_iac_dir(self, tmp_path: Path) -> Path:
+        """Create a temporary IaC directory for testing."""
+        iac_dir = tmp_path / "iac"
+        iac_dir.mkdir()
+        # Create a dummy Terraform file to make it a valid IaC directory
+        (iac_dir / "main.tf").write_text("# Dummy Terraform file")
+        return iac_dir
+
+    @patch("src.commands.deploy.deploy_iac")
+    def test_deploy_with_explicit_tenant_id_flag(
+        self, mock_deploy_iac: MagicMock, mock_iac_dir: Path
+    ):
+        """Test that deploy works with explicit --target-tenant-id flag."""
+        mock_deploy_iac.return_value = {
+            "status": "success",
+            "format": "terraform",
+            "output": "Deployment successful",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy_command,
+            [
+                "--iac-dir",
+                str(mock_iac_dir),
+                "--target-tenant-id",
+                "test-tenant-123",
+                "--resource-group",
+                "test-rg",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Deployment completed successfully" in result.output
+        mock_deploy_iac.assert_called_once()
+        # Verify the tenant ID was passed correctly
+        call_args = mock_deploy_iac.call_args
+        assert call_args[1]["target_tenant_id"] == "test-tenant-123"
+
+    @patch("src.commands.deploy.deploy_iac")
+    def test_deploy_with_env_fallback(
+        self, mock_deploy_iac: MagicMock, mock_iac_dir: Path
+    ):
+        """Test that deploy falls back to AZURE_TENANT_ID from environment."""
+        mock_deploy_iac.return_value = {
+            "status": "success",
+            "format": "terraform",
+            "output": "Deployment successful",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy_command,
+            [
+                "--iac-dir",
+                str(mock_iac_dir),
+                "--resource-group",
+                "test-rg",
+            ],
+            env={"AZURE_TENANT_ID": "env-tenant-456"},
+        )
+
+        assert result.exit_code == 0
+        assert "Deployment completed successfully" in result.output
+        mock_deploy_iac.assert_called_once()
+        # Verify the tenant ID from env was used
+        call_args = mock_deploy_iac.call_args
+        assert call_args[1]["target_tenant_id"] == "env-tenant-456"
+
+    @patch("src.commands.deploy.deploy_iac")
+    def test_deploy_flag_overrides_env(
+        self, mock_deploy_iac: MagicMock, mock_iac_dir: Path
+    ):
+        """Test that explicit --target-tenant-id flag overrides AZURE_TENANT_ID env."""
+        mock_deploy_iac.return_value = {
+            "status": "success",
+            "format": "terraform",
+            "output": "Deployment successful",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy_command,
+            [
+                "--iac-dir",
+                str(mock_iac_dir),
+                "--target-tenant-id",
+                "flag-tenant-789",
+                "--resource-group",
+                "test-rg",
+            ],
+            env={"AZURE_TENANT_ID": "env-tenant-456"},
+        )
+
+        assert result.exit_code == 0
+        assert "Deployment completed successfully" in result.output
+        mock_deploy_iac.assert_called_once()
+        # Verify the flag value takes precedence
+        call_args = mock_deploy_iac.call_args
+        assert call_args[1]["target_tenant_id"] == "flag-tenant-789"
+
+    def test_deploy_error_when_no_tenant_id(self, mock_iac_dir: Path):
+        """Test that deploy errors when no tenant ID provided from any source."""
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy_command,
+            [
+                "--iac-dir",
+                str(mock_iac_dir),
+                "--resource-group",
+                "test-rg",
+            ],
+            env={},  # No AZURE_TENANT_ID in environment
+        )
+
+        assert result.exit_code == 1
+        assert "No target tenant ID provided" in result.output
+        assert "AZURE_TENANT_ID not set" in result.output


### PR DESCRIPTION
## Summary

Makes deploy command consistent with other commands (scan, spec, mcp) by supporting AZURE_TENANT_ID environment variable fallback when --target-tenant-id flag is not provided.

## Changes

- Changed `--target-tenant-id` from `required=True` to `required=False`
- Added fallback logic: `target_tenant_id or os.environ.get("AZURE_TENANT_ID")`
- Updated help text to indicate .env fallback support
- Added error handling when neither flag nor env provides tenant ID
- Updated all internal usages to use `effective_tenant_id`
- Added comprehensive unit tests for all scenarios

## Test Results

### Step 13: Local Testing Results

**Test Environment**: worktrees/feat-issue-779-deploy-env-tenant, 2026-01-20

**Tests Executed**:
1. **Simple: Unit tests verification** → ✅ PASSED
   - All 4 unit tests passed (explicit flag, env fallback, flag overrides env, error when missing)
   - Test file: `tests/commands/test_deploy_env_fallback.py`

2. **Complex: CLI help text verification** → ✅ PASSED
   - Verified `--target-tenant-id` no longer shows `[required]` marker
   - Confirmed help text shows "(defaults to AZURE_TENANT_ID from .env)"
   - Command: `atg deploy --help`

**Regressions**: ✅ None detected
- Pre-commit hooks passed (ruff, ruff-format, bandit, detect-secrets)
- Only changes in deploy.py and new test file
- Existing functionality preserved (flag still works as before)

**Issues Found**: None - all tests passed on first attempt

## Philosophy Compliance

- ✅ Follows established pattern (scan.py, spec.py, mcp.py)
- ✅ Zero-BS implementation (no stubs, works immediately)
- ✅ Ruthless simplicity (~8 lines changed, no over-engineering)
- ✅ Clear error messages
- ✅ Test ratio 14.6:1 (within acceptable range for config changes)

## Breaking Changes

None. This change is backward compatible:
- Existing usage with --target-tenant-id flag continues to work
- New behavior only activates when flag is omitted and AZURE_TENANT_ID is set

Fixes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)