### PR TITLE
fix(iac): Remove tenant ID leak in KeyVault Terraform handler (Issue #475, Phase 2, File 1/3)

### DIFF
--- a/src/iac/emitters/terraform/handlers/keyvault/vault.py
+++ b/src/iac/emitters/terraform/handlers/keyvault/vault.py
@@ -82,12 +82,12 @@ class KeyVaultHandler(ResourceHandler):
         config["sku_name"] = sku_name.lower()  # Fix #596: Terraform requires lowercase
 
         # Tenant ID (required) - Fix #604: Use target tenant ID for cross-tenant deployment
-        # Priority: target_tenant_id (cross-tenant) > source tenantId (same-tenant)
-        tenant_id = context.target_tenant_id or properties.get("tenantId")
-        if tenant_id:
-            config["tenant_id"] = tenant_id
+        # ISSUE #475: NEVER use raw source tenantId - it leaks source tenant GUID
+        # Priority: target_tenant_id (cross-tenant) > variable reference (same-tenant)
+        if context.target_tenant_id:
+            config["tenant_id"] = context.target_tenant_id
         else:
-            # Use variable reference
+            # Use variable reference - NEVER fall back to properties.get("tenantId")
             config["tenant_id"] = "${var.tenant_id}"
 
         # Soft delete settings


### PR DESCRIPTION
## Summary

Fixes KeyVault Terraform handler to prevent source tenant GUID from leaking into generated Infrastructure-as-Code. This is Phase 2, File 1/3 of Issue #475 ID Leakage Audit (IaC Emitter Hardening).

## The Bug

**Line 86** had a dangerous fallback:
```python
tenant_id = context.target_tenant_id or properties.get("tenantId")
```

When `context.target_tenant_id` is None (single-tenant scenarios), this leaked the **raw source tenant GUID** from Azure properties into the generated Terraform configuration.

## The Fix

Remove the fallback to raw properties:
```python
if context.target_tenant_id:
    config["tenant_id"] = context.target_tenant_id
else:
    # Use variable reference - NEVER fall back to properties.get("tenantId")
    config["tenant_id"] = "${var.tenant_id}"
```

**Now**:
- Cross-tenant: Uses `context.target_tenant_id` ✅
- Same-tenant: Uses variable reference `${var.tenant_id}` ✅
- **Never** leaks source tenant GUID ✅

## Impact

**Before**: Source tenant GUID leaked into Key Vault Terraform when target_tenant_id was None  
**After**: Variable reference used, no GUID leakage

This prevents cross-tenant deployment failures where source tenant IDs make it into target tenant infrastructure code.

## Phase Strategy

This PR is **Phase 2, File 1/3** of the comprehensive ID leakage fix:

**Phase 1: Core Abstraction Service** (3 files)
- ✅ `identity_collector.py` (PR #788 - MERGED)
- ✅ `managed_identity_resolver.py` (PR #789 - PENDING)
- ✅ `node_manager.py` (already complete)

**Phase 2: IaC Emitter Hardening** (3 files)
- ✅ `keyvault/vault.py` (THIS PR)
- ⏳ `arm_emitter.py` (NEXT)
- ⏳ `bicep_emitter.py`

**Phase 3: Relationship Layer Protection** (2 files)

## Related

- Issue: #475 (ID Leakage Audit - 12 leak points)
- Strategy: `docs/id_leak_fix_strategy.md`
- Previous: PR #788 (MERGED), PR #789 (PENDING)

## Success Criteria

- ✅ No breaking changes (variable reference is standard Terraform)
- ✅ Source tenant GUID never exposed
- ✅ Cross-tenant deployment still works (uses target_tenant_id)
- ✅ Same-tenant deployment uses variable reference

Fixes #475 (partial - Phase 2 File 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)