### PR TITLE
fix(iac): Abstract principal IDs in ARM emitter aad_objects.json (Issue #475, Phase 2, File 2/3)

### DIFF
--- a/src/iac/emitters/arm_emitter.py
+++ b/src/iac/emitters/arm_emitter.py
@@ -15,6 +15,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from src.services.id_abstraction_service import get_id_abstraction_service
+
 from ..traverser import TenantGraph
 from . import register_emitter
 from .base import IaCEmitter
@@ -32,11 +34,13 @@ class ArmEmitter(IaCEmitter):
         target_tenant_id: Optional[str] = None,
         identity_mapping: Optional[Dict[str, Any]] = None,
         source_tenant_id: Optional[str] = None,
+        tenant_seed: Optional[str] = None,
     ):
         """Initialize ArmEmitter with optional cross-tenant translation.
 
         Bug #69 fix: Add cross-tenant translation support for ARM templates.
         Bug #107 fix: Add source_tenant_id parameter for same-tenant detection.
+        Issue #475: Add tenant_seed for ID abstraction to prevent GUID leakage.
 
         Args:
             config: Optional emitter-specific configuration
@@ -44,10 +48,15 @@ class ArmEmitter(IaCEmitter):
             target_tenant_id: Target tenant ID for cross-tenant translation
             identity_mapping: Identity mapping dictionary for Entra ID translation
             source_tenant_id: Source tenant ID for same-tenant detection (Bug #107)
+            tenant_seed: Tenant-specific seed for ID abstraction (Issue #475)
         """
         super().__init__(config)
         self.target_subscription_id = target_subscription_id
         self.target_tenant_id = target_tenant_id
+        self.tenant_seed = tenant_seed
+        self._id_service = (
+            get_id_abstraction_service(tenant_seed) if tenant_seed else None
+        )
         self.identity_mapping = identity_mapping
         self.source_tenant_id = source_tenant_id  # Bug #107 fix
 
@@ -81,7 +90,13 @@ class ArmEmitter(IaCEmitter):
                 pid = props.get("principalId")
                 ptype = (props.get("principalType") or "").lower()
                 if pid:
-                    entry = {"id": pid}
+                    # ISSUE #475: Abstract principal ID to prevent tenant GUID leakage
+                    abstracted_pid = (
+                        self._id_service.abstract_principal_id(pid)
+                        if self._id_service
+                        else pid
+                    )
+                    entry = {"id": abstracted_pid}
                     if ptype == "user":
                         aad_users.append(entry)
                     elif ptype == "group":


### PR DESCRIPTION
Fixes principal ID leak in ARM emitter where raw GUIDs were written to aad_objects.json. Phase 2, File 2/3 of Issue #475.

## The Bug
Lines 81-96 extracted raw principal IDs from role assignments and wrote them directly to aad_objects.json WITHOUT abstraction.

## The Fix
- Added tenant_seed parameter to ArmEmitter
- Initialized ID abstraction service  
- Abstract principal IDs before adding to AAD collections

Fixes #475 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)