### PR TITLE
feat(security): Add rate limiting for ATG Remote (Issue #580, Feature 1/4)

### DIFF
--- a/src/remote/server/main.py
+++ b/src/remote/server/main.py
@@ -24,6 +24,7 @@ from ..common.exceptions import AuthenticationError, RemoteError
 from ..db.connection_manager import ConnectionManager
 from .config import ATGServerConfig, Neo4jConfig
 from .dependencies import set_config, set_connection_manager
+from .middleware import RateLimiter
 from .routers import generate, health, operations, scan
 from .routers import websocket as ws_router
 
@@ -121,6 +122,10 @@ app.add_middleware(
     allow_methods=["GET", "POST", "DELETE"],  # Explicit methods only
     allow_headers=["Authorization", "Content-Type"],  # Explicit headers only
 )
+
+# Issue #580: Add rate limiting (10 scans per hour)
+app.add_middleware(RateLimiter, requests_per_hour=10)
+logger.info("Rate limiting enabled: 10 scans per hour")
 
 
 # Exception handlers

--- a/src/remote/server/middleware/__init__.py
+++ b/src/remote/server/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""Middleware components for ATG Remote Service."""
+
+from .rate_limiter import RateLimiter
+
+__all__ = ["RateLimiter"]

--- a/src/remote/server/middleware/rate_limiter.py
+++ b/src/remote/server/middleware/rate_limiter.py
@@ -1,0 +1,113 @@
+"""Rate limiting middleware for ATG Remote Service.
+
+Philosophy:
+- Ruthless simplicity: In-memory rate limiting (no Redis dependency)
+- Production-ready: 10 scans per hour limit
+- Clear error messages: Tell users when they're rate limited
+
+Issue #580: Security hardening for production deployment
+"""
+
+import logging
+import time
+from collections import defaultdict
+from typing import Dict, Tuple
+
+from fastapi import HTTPException, Request, status
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+
+class RateLimiter(BaseHTTPMiddleware):
+    """Simple in-memory rate limiter for scan operations.
+
+    Limits scan operations to 10 per hour per API key to prevent abuse.
+    """
+
+    def __init__(self, app, requests_per_hour: int = 10):
+        """Initialize rate limiter.
+
+        Args:
+            app: FastAPI application
+            requests_per_hour: Maximum requests allowed per hour (default: 10)
+        """
+        super().__init__(app)
+        self.requests_per_hour = requests_per_hour
+        self.window_seconds = 3600  # 1 hour
+        # Track: api_key -> list of (timestamp, endpoint) tuples
+        self._requests: Dict[str, list[Tuple[float, str]]] = defaultdict(list)
+        logger.info(
+            f"Rate limiter initialized: {requests_per_hour} requests per hour"
+        )
+
+    async def dispatch(self, request: Request, call_next):
+        """Process request with rate limiting."""
+        # Only rate limit scan endpoints
+        if not request.url.path.startswith("/scan"):
+            return await call_next(request)
+
+        # Get API key from header
+        api_key = request.headers.get("X-API-Key", "anonymous")
+
+        # Clean old entries and check rate limit
+        current_time = time.time()
+        self._clean_old_entries(api_key, current_time)
+
+        if self._is_rate_limited(api_key):
+            logger.warning(f"Rate limit exceeded for API key: {api_key[:8]}...")
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail={
+                    "error": "Rate limit exceeded",
+                    "limit": f"{self.requests_per_hour} scans per hour",
+                    "retry_after": self._get_retry_after(api_key),
+                },
+            )
+
+        # Record this request
+        self._requests[api_key].append((current_time, request.url.path))
+
+        # Process request
+        return await call_next(request)
+
+    def _clean_old_entries(self, api_key: str, current_time: float) -> None:
+        """Remove entries older than the time window."""
+        cutoff = current_time - self.window_seconds
+        self._requests[api_key] = [
+            (ts, path)
+            for ts, path in self._requests[api_key]
+            if ts > cutoff
+        ]
+
+    def _is_rate_limited(self, api_key: str) -> bool:
+        """Check if API key has exceeded rate limit."""
+        return len(self._requests[api_key]) >= self.requests_per_hour
+
+    def _get_retry_after(self, api_key: str) -> int:
+        """Get seconds until next request allowed."""
+        if not self._requests[api_key]:
+            return 0
+
+        oldest_request = min(ts for ts, _ in self._requests[api_key])
+        retry_after = int((oldest_request + self.window_seconds) - time.time())
+        return max(0, retry_after)
+
+    def get_stats(self, api_key: str) -> Dict[str, int]:
+        """Get rate limit stats for an API key."""
+        current_time = time.time()
+        self._clean_old_entries(api_key, current_time)
+
+        return {
+            "requests_used": len(self._requests[api_key]),
+            "requests_remaining": max(
+                0, self.requests_per_hour - len(self._requests[api_key])
+            ),
+            "window_seconds": self.window_seconds,
+            "retry_after": self._get_retry_after(api_key)
+            if self._is_rate_limited(api_key)
+            else 0,
+        }
+
+
+__all__ = ["RateLimiter"]


### PR DESCRIPTION
Adds production-grade rate limiting to prevent abuse. Limits scan operations to 10/hour per API key.

## Summary
- In-memory rate limiter (no Redis dependency)
- 10 scans per hour limit
- HTTP 429 with retry_after guidance
- Clean API for stats

Part 1/4 of Issue #580 security hardening.

Fixes #580 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)