### PR TITLE
feat(security): Add TLS enforcement for ATG Remote production (Issue #580, Feature 2/4)

### DIFF
--- a/src/remote/server/middleware/__init__.py
+++ b/src/remote/server/middleware/__init__.py
@@ -1,5 +1,6 @@
 """Middleware components for ATG Remote Service."""
 
 from .rate_limiter import RateLimiter
+from .tls_enforcement import TLSEnforcement
 
-__all__ = ["RateLimiter"]
+__all__ = ["RateLimiter", "TLSEnforcement"]

--- a/src/remote/server/middleware/tls_enforcement.py
+++ b/src/remote/server/middleware/tls_enforcement.py
@@ -1,0 +1,66 @@
+"""TLS enforcement middleware for production security.
+
+Philosophy:
+- Ruthless simplicity: Simple HTTPS check
+- Environment-aware: Only enforced in production
+- Clear errors: Tell users to use HTTPS
+
+Issue #580: Security hardening for production deployment
+"""
+
+import logging
+import os
+
+from fastapi import HTTPException, Request, status
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+
+class TLSEnforcement(BaseHTTPMiddleware):
+    """Enforce HTTPS in production environments.
+
+    Rejects non-HTTPS requests with clear error message.
+    Disabled in development for easier testing.
+    """
+
+    def __init__(self, app, enforce: bool = True):
+        """Initialize TLS enforcement.
+
+        Args:
+            app: FastAPI application
+            enforce: Whether to enforce TLS (default: True in production)
+        """
+        super().__init__(app)
+        # Auto-detect environment
+        environment = os.getenv("ENVIRONMENT", "production").lower()
+        self.enforce = enforce and environment == "production"
+        logger.info(
+            f"TLS enforcement: {'ENABLED' if self.enforce else 'DISABLED'} "
+            f"(environment={environment})"
+        )
+
+    async def dispatch(self, request: Request, call_next):
+        """Process request with TLS enforcement."""
+        if not self.enforce:
+            return await call_next(request)
+
+        # Check if request is HTTPS
+        if request.url.scheme != "https":
+            logger.warning(
+                f"Rejected non-HTTPS request: {request.method} {request.url.path}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "HTTPS required",
+                    "message": "This service requires HTTPS in production. "
+                    "Please use https:// instead of http://",
+                    "documentation": "See docs/security/ for TLS setup",
+                },
+            )
+
+        return await call_next(request)
+
+
+__all__ = ["TLSEnforcement"]


### PR DESCRIPTION
Enforces HTTPS in production. Rejects non-HTTPS with HTTP 403.

## Summary
- TLS enforcement middleware
- Production only (disabled in dev)
- Clear error messages

Feature 2/4 of Issue #580.

Fixes #580 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)