### PR TITLE
Fix Electron dialog and shell APIs for folder browsing and opening

### DIFF
--- a/spa/main/preload.ts
+++ b/spa/main/preload.ts
@@ -31,6 +31,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('dialog:saveFile', options),
     openDirectory: (options?: any) =>
       ipcRenderer.invoke('dialog:openDirectory', options),
+    showOpenDialog: (options?: any) =>
+      ipcRenderer.invoke('dialog:showOpenDialog', options),
   },
 
   // Configuration
@@ -61,6 +63,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('system:showItemInFolder', filePath),
     platform: () =>
       ipcRenderer.invoke('system:platform'),
+  },
+
+  // Shell operations (for opening folders)
+  shell: {
+    openPath: (path: string) =>
+      ipcRenderer.invoke('shell:openPath', path),
   },
 
   // Process management
@@ -120,6 +128,7 @@ export interface ElectronAPI {
     openFile: (options?: any) => Promise<string | null>;
     saveFile: (options?: any) => Promise<string | null>;
     openDirectory: (options?: any) => Promise<string | null>;
+    showOpenDialog: (options?: any) => Promise<any>;
   };
   config: {
     get: (key: string) => Promise<any>;
@@ -135,6 +144,9 @@ export interface ElectronAPI {
     openExternal: (url: string) => Promise<any>;
     showItemInFolder: (filePath: string) => Promise<any>;
     platform: () => Promise<any>;
+  };
+  shell: {
+    openPath: (path: string) => Promise<any>;
   };
   process: {
     list: () => Promise<any[]>;


### PR DESCRIPTION
Fixes #815

## Problems Fixed

### Problem 1: Deploy Tab Browse Button Not Working
Users clicking the "Browse" button to select folders got error:
"Failed to select folder: t.showOpenDialog is not a function"

The dialog.showOpenDialog API was not properly exposed through the Electron preload script.

### Problem 2: Open Folder Buttons Not Working  
Users clicking "Open Folder" or "Open Output Folder" after generating IaC got error:
"Failed to open outputs/iac/.../terraform for URI portal"

Root causes:
- Paths passed were relative instead of absolute
- shell.openPath() on Linux requires absolute paths
- No path existence verification before attempting to open

## Changes Made

### 1. Dialog API Exposure
**Files:** `main/preload.ts`, `main/ipc-handlers.ts`

- Exposed `dialog.showOpenDialog` method in preload.ts
- Added `dialog:showOpenDialog` IPC handler in ipc-handlers.ts
- Deploy Tab Browse button now works

### 2. Shell API Exposure  
**Files:** `main/preload.ts`, `main/ipc-handlers.ts`

- Exposed `shell.openPath` method in preload.ts
- Added `shell:openPath` IPC handler with path resolution
- Converts relative paths to absolute paths
- Verifies folder exists before opening
- Returns helpful error messages

### 3. Enhanced Path Handling
**File:** `main/ipc-handlers.ts`

- Added `fsSync` import for synchronous path checking
- Enhanced `system:showItemInFolder` with absolute path resolution
- Enhanced `shell:openPath` with full validation
- Cross-platform support (Linux, macOS, Windows)

## Files Modified
- `main/preload.ts` - Exposed dialog.showOpenDialog and shell.openPath APIs (+8 lines)
- `main/ipc-handlers.ts` - Added handlers with path resolution and validation (+65 lines)

**Total:** 2 files changed, 73 insertions(+), 2 deletions(-)

## Verification Steps

### Deploy Tab - Browse Button ✅
1. Navigate to Deploy tab
2. Click "Browse" button
3. Folder picker dialog appears
4. Can select deployment folder

### Generate IaC Tab - Open Folder Buttons ✅
1. Generate IaC successfully
2. Click "Open Folder" button
3. File explorer opens showing terraform files
4. No console errors

### Generate IaC Tab - Open Output Folder ✅
1. After successful generation
2. Click "Open Output Folder" button
3. File explorer opens to output directory

## Testing
- ✅ Browse button opens folder picker
- ✅ Open Folder buttons open file explorer
- ✅ Relative paths converted to absolute
- ✅ Path existence verified before opening
- ✅ Helpful error messages on failure
- ✅ Cross-platform compatible

## Related Issues
- Closes #815