### PR TITLE
feat: Enforce Azure 1-Bastion-per-VNet limit (Issue #327)

### DIFF
--- a/src/iac/emitters/terraform/context.py
+++ b/src/iac/emitters/terraform/context.py
@@ -49,6 +49,9 @@ class EmitterContext:
     # VNet ID mapping for subnet references (Bug #31)
     vnet_id_to_terraform_name: Dict[str, str] = field(default_factory=dict)
 
+    # Bastion Host VNet tracking (Issue #327 - 1 Bastion per VNet limit)
+    vnets_with_bastions: Set[str] = field(default_factory=set)
+
     # Association tracking (emitted after main resources)
     nsg_associations: List[tuple] = field(default_factory=list)
     nic_nsg_associations: List[tuple] = field(default_factory=list)


### PR DESCRIPTION
## Summary
Implements VNet-level deduplication for Bastion Hosts to enforce Azure's hard limit of 1 Bastion per virtual network. This prevents IaC generation from creating invalid Terraform configurations that would fail at deployment.

**Key Changes:**
- Added `vnets_with_bastions` Set to `EmitterContext` for VNet tracking
- Modified `BastionHostHandler.emit()` to check VNet tracking before emission
- Skip duplicate Bastions with clear warning: `"Skipping Bastion Host 'X': VNet 'Y' already has a Bastion. Azure enforces a limit of 1 Bastion per VNet."`
- Added `_extract_vnet_id_from_subnet()` helper method to extract VNet ID from subnet resource ID

**Test Coverage:**
- 5 new tests covering all scenarios:
  - First Bastion per VNet is successfully emitted
  - Second Bastion on same VNet is skipped with warning
  - Multiple Bastions on different VNets are all emitted
  - Bastion without valid subnet doesn't affect VNet tracking
  - VNet ID extraction helper method works correctly
- Also fixed existing test bug: `reference_type` → `resource_type`

**Files Modified:**
- `src/iac/emitters/terraform/context.py` - Added VNet tracking field
- `src/iac/emitters/terraform/handlers/network/bastion.py` - Added VNet limit enforcement logic
- `tests/iac/handlers/test_bastion_handler.py` - Added comprehensive tests + fixed existing bug

## Test Plan
- [x] All 16 bastion handler tests pass (11 existing + 5 new)
- [x] VNet limit enforcement working correctly
- [x] Warning logs generated for skipped Bastions
- [x] No impact on Bastions in different VNets

## Related Issue
Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)