### PR TITLE
Fix GitHub Pages documentation links (Issue #878)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,4 +55,4 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Documentation has been successfully deployed to GitHub Pages." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 **[View Documentation](https://rysweet.github.io/pr600/)**" >> $GITHUB_STEP_SUMMARY
+          echo "🔗 **[View Documentation](https://rysweet.github.io/azure-tenant-grapher/)**" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Azure Tenant Grapher discovers every resource in your Azure tenant, stores the r
 
 ![Azure Tenant Grapher Screenshot](docs/resources/screenshot.png)
 
-> **📚 [View Complete Documentation](https://docs.github.com/en/pages)** - Full guides, tutorials, and API reference on GitHub Pages
+> **📚 [View Complete Documentation](https://rysweet.github.io/azure-tenant-grapher/)** - Full guides, tutorials, and API reference on GitHub Pages
 
 ---
 
@@ -431,24 +431,24 @@ You can run the above command directly, or use the provided helper script (`scri
 All test output artifacts are excluded from version control via `.gitignore`.
 ## Documentation
 
-**📚 [Complete Documentation on GitHub Pages](https://rysweet.github.io/pr600/)** - Full guides, tutorials, architecture docs, and API reference
+**📚 [Complete Documentation on GitHub Pages](https://rysweet.github.io/azure-tenant-grapher/)** - Full guides, tutorials, architecture docs, and API reference
 
 ### Quick Links
 
 - **Getting Started**
-  - [Installation Guide](https://rysweet.github.io/pr600/quickstart/installation/)
-  - [Quick Start Tutorial](https://rysweet.github.io/pr600/quickstart/quick-start/)
-  - [First Autonomous Deployment](https://rysweet.github.io/pr600/quickstart/AGENT_DEPLOYMENT_TUTORIAL/)
+  - [Installation Guide](https://rysweet.github.io/azure-tenant-grapher/quickstart/installation/)
+  - [Quick Start Tutorial](https://rysweet.github.io/azure-tenant-grapher/quickstart/quick-start/)
+  - [First Autonomous Deployment](https://rysweet.github.io/azure-tenant-grapher/quickstart/AGENT_DEPLOYMENT_TUTORIAL/)
 
 - **User Guides**
-  - [Autonomous Deployment Guide](https://rysweet.github.io/pr600/guides/AUTONOMOUS_DEPLOYMENT/)
-  - [Autonomous Deployment FAQ](https://rysweet.github.io/pr600/guides/AUTONOMOUS_DEPLOYMENT_FAQ/)
-  - [Terraform Import Troubleshooting](https://rysweet.github.io/pr600/guides/TERRAFORM_IMPORT_TROUBLESHOOTING/)
+  - [Autonomous Deployment Guide](https://rysweet.github.io/azure-tenant-grapher/guides/AUTONOMOUS_DEPLOYMENT/)
+  - [Autonomous Deployment FAQ](https://rysweet.github.io/azure-tenant-grapher/guides/AUTONOMOUS_DEPLOYMENT_FAQ/)
+  - [Terraform Import Troubleshooting](https://rysweet.github.io/azure-tenant-grapher/guides/TERRAFORM_IMPORT_TROUBLESHOOTING/)
 
 - **Architecture & Design**
-  - [Dual-Graph Architecture](https://rysweet.github.io/pr600/architecture/dual-graph/)
-  - [SCAN_SOURCE_NODE Relationships](https://rysweet.github.io/pr600/architecture/scan-source-node-relationships/)
-  - [Neo4j Schema Reference](https://rysweet.github.io/pr600/NEO4J_SCHEMA_REFERENCE/)
+  - [Dual-Graph Architecture](https://rysweet.github.io/azure-tenant-grapher/architecture/dual-graph/)
+  - [SCAN_SOURCE_NODE Relationships](https://rysweet.github.io/azure-tenant-grapher/architecture/scan-source-node-relationships/)
+  - [Neo4j Schema Reference](https://rysweet.github.io/azure-tenant-grapher/NEO4J_SCHEMA_REFERENCE/)
   - [Architecture-Based Replication](docs/ARCHITECTURE_BASED_REPLICATION.md) - Pattern-based tenant replication
   - [Architectural Pattern Analysis](docs/ARCHITECTURAL_PATTERN_ANALYSIS.md) - Detect Azure patterns
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing! This document provides guidelines f
 ## Getting Started
 
 1. Fork the repository
-2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/pr600.git`
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/azure-tenant-grapher.git`
 3. Create a feature branch: `git checkout -b feat/my-feature`
 4. Make your changes
 5. Test your changes
@@ -188,8 +188,8 @@ Include:
 
 ## Questions?
 
-- Check existing [issues](https://github.com/rysweet/pr600/issues)
-- Read the [documentation](https://rysweet.github.io/pr600/)
+- Check existing [issues](https://github.com/rysweet/azure-tenant-grapher/issues)
+- Read the [documentation](https://rysweet.github.io/azure-tenant-grapher/)
 - Ask in GitHub Discussions
 
 ## License

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -16,11 +16,11 @@ Complete development environment setup for contributing to Azure Tenant Grapher.
 
 ```bash
 # Fork on GitHub first, then clone your fork
-git clone https://github.com/YOUR_USERNAME/pr600.git
-cd pr600
+git clone https://github.com/YOUR_USERNAME/azure-tenant-grapher.git
+cd azure-tenant-grapher
 
 # Add upstream remote
-git remote add upstream https://github.com/rysweet/pr600.git
+git remote add upstream https://github.com/rysweet/azure-tenant-grapher.git
 ```
 
 ### 2. Install Dependencies
@@ -337,6 +337,6 @@ uv sync
 
 ## Getting Help
 
-- Check [GitHub Issues](https://github.com/rysweet/pr600/issues)
-- Read [Documentation](https://rysweet.github.io/pr600/)
+- Check [GitHub Issues](https://github.com/rysweet/azure-tenant-grapher/issues)
+- Read [Documentation](https://rysweet.github.io/azure-tenant-grapher/)
 - Ask in GitHub Discussions

--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -12,8 +12,8 @@
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/rysweet/pr600.git
-cd pr600
+git clone https://github.com/rysweet/azure-tenant-grapher.git
+cd azure-tenant-grapher
 ```
 
 ### 2. Install Dependencies

--- a/docs/quickstart/quick-start.md
+++ b/docs/quickstart/quick-start.md
@@ -149,4 +149,4 @@ atg scan --tenant-id <tenant> --limit 1000
 For more help:
 - [Documentation Index](../INDEX.md)
 - [Autonomous Deployment FAQ](../guides/AUTONOMOUS_DEPLOYMENT_FAQ.md)
-- [GitHub Issues](https://github.com/rysweet/pr600/issues)
+- [GitHub Issues](https://github.com/rysweet/azure-tenant-grapher/issues)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: Azure Tenant Grapher
 site_description: Security-focused tool that builds a Neo4j graph database representation of Azure tenant resources
 site_author: Azure Tenant Grapher Team
-site_url: https://rysweet.github.io/pr600
+site_url: https://rysweet.github.io/azure-tenant-grapher
 
-repo_url: https://github.com/rysweet/pr600
-repo_name: rysweet/pr600
+repo_url: https://github.com/rysweet/azure-tenant-grapher
+repo_name: rysweet/azure-tenant-grapher
 edit_uri: edit/main/docs/
 
 theme:
@@ -77,7 +77,7 @@ markdown_extensions:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/rysweet/pr600
+      link: https://github.com/rysweet/azure-tenant-grapher
   version:
     provider: mike
 


### PR DESCRIPTION
## Problem

The README.md and other documentation files contained incorrect GitHub Pages and repository links pointing to `pr600` instead of `azure-tenant-grapher`. This caused:
- Broken documentation link at the top of README.md
- Incorrect GitHub Pages URL in mkdocs.yml configuration
- Wrong repository references in documentation files
- 404 errors when users tried to access the documentation site

Related to Issue #878

## Solution

Updated all documentation URLs from `pr600` repository name to `azure-tenant-grapher`:
- Fixed README.md top-level documentation link (line 7)
- Updated all Quick Links in README.md documentation section
- Corrected mkdocs.yml configuration (site_url, repo_url, repo_name)
- Fixed GitHub Actions workflow deployment summary
- Updated git clone instructions in quickstart documentation
- Fixed issues and documentation links in CONTRIBUTING.md
- Updated development setup documentation

## Changes Made

**Files Modified (7 total):**
1. `README.md` - Top link and Quick Links section (22 lines)
2. `mkdocs.yml` - Site configuration (8 lines)
3. `.github/workflows/docs.yml` - Deployment summary (2 lines)
4. `docs/CONTRIBUTING.md` - Clone instructions and help links (6 lines)
5. `docs/development/setup.md` - Setup instructions and help links (10 lines)
6. `docs/quickstart/installation.md` - Installation commands (4 lines)
7. `docs/quickstart/quick-start.md` - Issues link (2 lines)

**Total Changes:** 27 insertions, 27 deletions (URL updates only, no functional changes)

## Step 13: Local Testing Results

**Test Environment**: feat/issue-878-fix-github-pages-link branch, 2026-01-29

**Tests Executed:**

1. **Simple - README.md verification**: Checked top-level documentation link → ✅ Correct URL
   ```bash
   grep -n "View Complete Documentation" README.md | head -1
   # Result: Line 7 now points to https://rysweet.github.io/azure-tenant-grapher/
   ```

2. **Complex - Comprehensive URL sweep**: Verified no pr600 references remain → ✅ Complete
   ```bash
   grep -r "pr600" --include="*.md" --include="*.yml" . | wc -l
   # Result: 0 references found
   ```

3. **Integration - mkdocs.yml configuration**: Verified all repository URLs updated → ✅ Consistent
   ```bash
   grep "azure-tenant-grapher" mkdocs.yml
   # Result: site_url, repo_url, repo_name all correct
   ```

**Regressions**: ✅ None detected - URL changes only, no functional modifications

**Issues Found**: None - all URLs successfully migrated from pr600 to azure-tenant-grapher

## Testing Notes

- This is a SIMPLE change (< 50 lines, documentation URLs only)
- No code changes, so no pre-commit hooks or unit tests required
- Verified all markdown files updated consistently
- GitHub Pages site deployment will occur after merge to main

## Success Criteria

- [x] All pr600 references removed from documentation
- [x] README.md links to correct GitHub Pages URL
- [x] mkdocs.yml configuration uses correct repository name
- [x] Git clone instructions reference correct repository
- [x] No functional changes to code or tests
- [x] All URLs consistent and correct
- [x] Step 13 mandatory local testing completed with documented results

🤖 Generated with Claude Code

---

**Ready for Review**: This PR contains only documentation URL fixes with no functional changes. All pr600 references have been eliminated and replaced with azure-tenant-grapher.